### PR TITLE
Clarifying the LIGO contract tutorial

### DIFF
--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -213,7 +213,7 @@ If it calls the reset endpoint, it does not pass any parameters.
 
    This code is an OCaml type called a *variant*, similar to an enumeration in many other languages, but with some other features.
 
-1. Add this code to create the `main` function, which defines entrypoints based on the variant in the previous step:
+1. Add this code to create the `main` function, which defines the entrypoints that the client can call:
 
    ```ocaml
    let main (action, store : parameter * storage) : operation list * storage =
@@ -224,10 +224,13 @@ If it calls the reset endpoint, it does not pass any parameters.
     | Reset         -> 0)
    ```
 
-   This function returns a list of entrypoints that the client can call and the new value of the storage:
+   Tezos entrypoints return two values: a list of other operations to call and the new value of the contract's storage.
+   In this case, the contract does not call any other operations, so the first return value is an empty list of operations, denoted by the code `([] : operation list)`.
 
-    - If the parameter is "Reset," the new value of the storage is 0.
-    - If the parameter is "Increment" or "Decrement," the function passes the storage and the integer that the client sent to the `add` or `sub` functions, which you create in the next step.
+   The second return value, the new value of the contract's storage, depends on which endpoint the client called:
+
+    - If the client calls the "Reset" entrypoint, the new value of the storage is 0.
+    - If the client calls the "Increment" or "Decrement" entrypoints the function passes the storage and the integer that the client sent to the `add` or `sub` functions, which you create in the next step.
 
 1. Add these functions to increment or decrement the storage:
 
@@ -239,7 +242,7 @@ If it calls the reset endpoint, it does not pass any parameters.
    ```
 
    These functions receive a tuple as a parameter, which includes the current value of the storage in the `store` variable and the value that the client passed in the `inc` or `dec` variables.
-   Then they set the new value of the storage based on those parameters.
+   Then return the new value of the storage based on those parameters.
 
 The complete contract code looks like this:
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -70,57 +70,55 @@ This tutorial uses CameLigo, but you do not need any experience with OCaml to ru
 
 ## Create a project folder
 
-Now we can go ahead and create a folder somewhere on our local drive with the name of the project. Let's call it `example-smart-contract`.
+Follow these steps to create a LIGO project:
 
-```bash
-mkdir example-smart-contract
-```
+1. On the command-line terminal, create a folder for the project and open it.
+You can name your project anything you want, such as `example-smart-contract`.
 
-```bash
-cd example-smart-contract
-```
+   ```bash
+   mkdir example-smart-contract
+   cd example-smart-contract
+   ```
 
-## Create a project file
+1. Create a file named `increment.mligo` in the project folder.
+This is where the contract code goes.
 
-Inside the `example-smart-contract` folder, let's create a file called `increment.mligo` and save it. We'll need this file later.
+   ```bash
+   touch increment.mligo
+   ```
 
-```bash
-touch increment.mligo
-```
+## Switch to a testnet
 
-## Switch to a Testnet
+Before you deploy your contract to the main Tezos network (referred to as *mainnet*), you can deploy it to a testnet.
+Testnets are useful for testing Tezos operations because testnets provide tokens for free so you can work with them without spending real tokens.
 
-Before going further let's make sure we're working on a [Testnet](https://teztnets.xyz).&#x20;
+Tezos testnets are listed on this site: <https://teztnets.xyz/>.
 
-View the available Testnets:
+The [Ghostnet](https://teztnets.xyz/ghostnet-about) testnet is a good choice for testing because it is intended to be long-lived, as opposed to shorter-term testnets that allow people to test new Tezos features.
 
-``` sh
-https://teztnets.xyz
-```
+Follow these steps to set your Octez client to use a testnet instead of the main network:
 
-The [Ghostnet](https://teztnets.xyz/ghostnet-about) might be a good choice for this guide (at the time of writing).&#x20;
+1. On <https://teztnets.xyz/>, click the testnet to use, such as ghostnet.
 
-Copy the _Public RPC endpoint_ which looks something like this:
+1. Copy the one of the testnet's public RPC endpoints, such as `https://rpc.ghostnet.teztnets.xyz`.
 
-``` sh
-https://rpc.ghostnet.teztnets.xyz
-```
+1. Set your Octez client to use this testnet by running this command on the command line, replacing the testnet RPC URL with the URL that you copied:
 
-Make sure we use this endpoint by running:
+   ```bash
+   octez-client --endpoint https://rpc.ghostnet.teztnets.xyz config update
+   ```
 
-```bash
-octez-client --endpoint https://rpc.ghostnet.teztnets.xyz config update
-```
+   Octez shows a warning that you are using a testnet instead of mainnet.
+
+1. Verify that you are using a testnet by running this command:
+
+   ```bash
+   octez-client config show
+   ```
+
+   The response from Octez includes the URL of the testnet.
 
 You should then see something like this returned:
-
-``` sh
-Warning:
-
-                 This is NOT the Tezos Mainnet.
-
-           Do NOT use your fundraiser keys on this network.
-```
 
 ## Create a local wallet
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -353,3 +353,4 @@ Now the contract is running on the Tezos blockchain.
 You or any other user can call it from any source that can send transactions to Tezos, including Octez, dApps, and other contracts.
 
 If you want to continue working with this contract, try creating a dApp to call it from a web application, similar to the dApp that you create in the tutorial [Build your first app on Tezos](../../build-your-first-app/).
+You can also try adding your own endpoints and originating a new contract, but you cannot update the existing contract after it is deployed.

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -183,12 +183,12 @@ The contract that you will create has these basic parts:
 The storage can be a primitive type such as an integer, string, or timestamp, or a complex data type that contains multiple values.
 For more information on contract data types, see [Smart contract concepts](../../../smart-contracts/smart-contracts-concepts/).
 
-- A single entrypoint named `main` that clients can call.
-Contracts can have any number of endpoints, but for simplicity, this contract uses only one endpoint.
+- A function named `main` that defines the contract's _entrypoints_, which are functions that clients can call, like endpoints in an API.
+Contracts can have any number of entrypoints.
 
 - A definition for the parameter that determines whether the contract increments, decrements, or resets the storage.
 
-- Internal functions that describe what to do when clients call the contract.
+- Internal functions that run code when clients call the contract.
 
 Follow these steps to create the code for the contract:
 
@@ -200,7 +200,9 @@ Follow these steps to create the code for the contract:
    type storage = int
    ```
 
-1. Add this code to create the parameter that tells the contract what to do:
+1. Add this code to define the parameters that the contract accepts.
+In this case, if the client calls the increment or decrement endpoints, it must pass an integer.
+If it calls the reset endpoint, it does not pass any parameters.
 
    ```ocaml
    type parameter =
@@ -209,12 +211,9 @@ Follow these steps to create the code for the contract:
    | Reset
    ```
 
-   This parameter is an OCaml type called a *variant*, similar to an enumeration in many other languages, but with some other features.
+   This code is an OCaml type called a *variant*, similar to an enumeration in many other languages, but with some other features.
 
-   The contract uses different branches of this variant to simulate entrypoints for the contract contract.
-   In this case, you can imagine that there is an **Increment** entrypoint, a **Decrement** entrypoint, and a **Reset** entrypoint, even though technically the contract will have only one endpoint, named `main`.
-
-1. Add this code to create the `main` endpoint:
+1. Add this code to create the `main` function, which defines entrypoints based on the variant in the previous step:
 
    ```ocaml
    let main (action, store : parameter * storage) : operation list * storage =
@@ -225,12 +224,10 @@ Follow these steps to create the code for the contract:
     | Reset         -> 0)
    ```
 
-   This endpoint accepts the increment, decrement, or reset parameter and refers to it as the `action` variable.
-   It also accepts the current value of the storage as the `store` variable.
-   Then it uses the OCaml `match` command to map the `action` variable to the new value of the storage:
+   This function returns a list of entrypoints that the client can call and the new value of the storage:
 
     - If the parameter is "Reset," the new value of the storage is 0.
-    - If the parameter is "Increment" or "Decrement," the function passes the integer that the client sent to the `add` or `sub` functions, which you create in the next step.
+    - If the parameter is "Increment" or "Decrement," the function passes the storage and the integer that the client sent to the `add` or `sub` functions, which you create in the next step.
 
 1. Add these functions to increment or decrement the storage:
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -19,8 +19,8 @@ In this tutorial, you will learn how to:
 - Get tokens from a faucet
 - Code a contract in LIGO, including:
   - Defining the storage for the contract
-  - Defining endpoints in the contract
-  - Writing code to run when the endpoints are called
+  - Defining entrypoints in the contract
+  - Writing code to run when the entrypoints are called
 - Deploy (or originate) the contract to Tezos and set its starting storage value
 - Look up the current state of the contract
 - Call the contract from the command line
@@ -28,7 +28,7 @@ In this tutorial, you will learn how to:
 ## Tutorial contract
 
 The contract that you deploy in this tutorial stores a single integer.
-It provides a single endpoint that users can call to change the value of that integer
+It provides entrypoints that clients can call to change the value of that integer:
 
 - The `increment` endpoint accepts an integer as a parameter and adds that integer to the value in storage
 - The `decrement` endpoint accepts an integer as a parameter and subtracts that integer to the value in storage
@@ -183,12 +183,9 @@ The contract that you will create has these basic parts:
 The storage can be a primitive type such as an integer, string, or timestamp, or a complex data type that contains multiple values.
 For more information on contract data types, see [Smart contract concepts](../../../smart-contracts/smart-contracts-concepts/).
 
-- A function named `main` that defines the contract's _entrypoints_, which are functions that clients can call, like endpoints in an API.
-Contracts can have any number of entrypoints.
+- Internal functions called entrypoints that run code when clients call the contract.
 
-- A definition for the parameter that determines whether the contract increments, decrements, or resets the storage.
-
-- Internal functions that run code when clients call the contract.
+- A type that describes the return value of the entrypoints.
 
 Follow these steps to create the code for the contract:
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -122,38 +122,36 @@ You should then see something like this returned:
 
 ## Create a local wallet
 
-We're now going to create a local wallet to use throughout this guide.
+Deploying a smart contract costs fees, so you need a local wallet and XTZ tokens.
+The Octez client can manage a local wallet for you, and you can get XTZ tokens on testnets from faucets.
 
-Run the following command to generate a local wallet with _octez-client_, making sure to replace `<my_wallet>` with a name of your choosing:
+1. Run the following command to generate a local wallet, replacing `local_wallet` with a name for your wallet:
 
-```bash
-octez-client gen keys local_wallet
-```
+   ```bash
+   octez-client gen keys local_wallet
+   ```
 
-Let's get the address for this wallet because we'll need it later:
+1. Get the address for the wallet by running this command, again replacing `local_wallet` with the name of your local wallet.
 
-```bash
-octez-client show address local_wallet
-```
+   ```bash
+   octez-client show address local_wallet
+   ```
 
-Which will return something like this:
+   The Octez client prints a warning that you are using a testnet and the address of the new wallet in the `hash` field.
+   The wallet address begins with `tz1`, `tz2`, or `tz3`, as in this example:
 
-``` sh
-Warning:
+   ```sh
+   Warning:
 
-                 This is NOT the Tezos Mainnet.
+                    This is NOT the Tezos Mainnet.
 
-           Do NOT use your fundraiser keys on this network.
+              Do NOT use your fundraiser keys on this network.
 
-Hash: tz1dW9Mk...........H67L
-Public Key: edp.............................bjbeDj
-```
+   Hash: tz1dW9Mk...........H67L
+   Public Key: edp.............................bjbeDj
+   ```
 
-We'll want to copy the Hash that starts with `tz` to your clipboard:
-
-``` sh
-tz1dW9Mk...........H67L
-```
+   You will need the wallet address to send funds to the wallet, to deploy the contract, and to send transactions to the contract.
 
 ## Fund your test wallet&#x20;
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -117,8 +117,6 @@ Follow these steps to set your Octez client to use a testnet instead of the main
 
    The response from Octez includes the URL of the testnet.
 
-You should then see something like this returned:
-
 ## Create a local wallet
 
 Deploying and using a smart contract costs fees, so you need a local wallet and XTZ tokens.

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -294,61 +294,68 @@ For example, this command sets the storage at 10 and increments it by 32:
 
 Now you can deploy the contract.
 
-## Originate to the Testnet
+## Deploying (originating) to the testnet
 
-Run the following command to originate the smart contract:
+Deploying a contract to the network is called "originating."
+Originating the contract requires a small amount of Tezos tokens as a fee.
+
+1. Run the following command to originate the smart contract, changing `$MY_TZ_ADDRESS` to the address of the wallet that you created earlier in the tutorial:
+
+   ```bash
+   octez-client originate contract my-counter \
+       transferring 0 from $MY_TZ_ADDRESS \
+       running increment.tz \
+       --init 10 --burn-cap 0.1 --force
+   ```
+
+   This command includes these parts:
+
+     - It uses the Octez client `originate contract` command to originate the contract and assigns the local name `my-counter` to the contract
+     - It includes 0 tokens from your wallet with the transaction, but the `--burn-cap` argument allows the transaction to take up to 0.1 XTZ from your wallet for fees.
+     - It sets the initial value of the contract storage to 10 with the `--init` argument.
+
+   If the contract deploys successfully, Octez shows the address of the new contract, as in this example:
+
+   ```bash
+   New contract KT1Nnk.................UFsJrq originated.
+   The operation has only been included 0 blocks ago.
+   We recommend to wait more.
+   ```
+
+1. Copy the contract address, which starts with `KT1`.
+
+1. Optional: Run the command `octez-client get balance for local_wallet` to get the updated balance of your wallet.
+
+1. Verify that the contract deployed successfully by finding it on a block explorer:
+
+  1. Open a Tezos block explorer such as [TzKT](https://tzkt.io) or [Better Call Dev](https://better-call.dev/).
+
+  1. Set the explorer to Ghostnet instead of mainnet.
+
+  1. Paste the contract address, which starts with `KT1`, into the search field and press Enter.
+
+  1. Go to the Storage tab to see that the initial value of the storage is 10.
+
+## Calling the contract
+
+Now you can call the contract from any Tezos client, including Octez.
+
+To increment the current storage by a certain value, call the `increment` entrypoint, as in this example:
+
 ```bash
-octez-client originate contract increment \
-    transferring 0 from <my_tz_address...> \
-    running increment.tz \
-    --init 10 --burn-cap 0.1 --force
+octez-client --wait none transfer 0 from local_wallet to my-counter --entrypoint 'increment' --arg '5' --burn-cap 0.1
 ```
 
-This will originate the contract with an initial storage of `10`.
+The previous example uses the local name `my-counter`.
+You can also specify the contract address.
 
-You should get a confirmation that your smart contract has been originated:
-
-```bash
-New contract KT1Nnk.................UFsJrq originated.
-The operation has only been included 0 blocks ago.
-We recommend to wait more.
-```
-
-Make sure you copy the contract address for the next step!
-
-## Confirm that all worked as expected
-
-To interact with the contract and confirm that all went as expected, you can use an Explorer such as: [TzKT](https://tzkt.io) or [Better Call Dev](https://better-call.dev/).
-
-Make sure you have switched to [Ghostnet](https://ghostnet.tzkt.io) before you start looking.
-
-Then paste the contract address (starting with KT1) `KT1Nnk.................UFsJrq` into the search field and hit `enter` to find it.
-
-Then navigate to the `Storage` tab to see your initial value of `10`.
-
-## Calling the entrypoints
-
-Now that we've successfully originated our smart contract, let's test out the three entrypoints that we created: `increment`, `decrement`, and `reset`.
-
-#### Increment
-
-To increment the current storage by a certain value, you can call the `increment` entrypoint:
-
-```bash
-octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'increment' --arg '5' --burn-cap 0.1
-```
-
-#### Decrement
-
-To decrement the current storage by a certain value, you can call the `decrement` entrypoint:
+To decrement the current storage by a certain value, call the `decrement` entrypoint, as in this example:
 
 ```bash
 octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'decrement' --arg '6' --burn-cap 0.1
 ```
 
-#### Reset
-
-Finally, to reset the current storage to zero, you can call the `reset` entrypoint:
+Finally, to reset the current storage to zero, call the `reset` entrypoint, as in this example:
 
 ```bash
 octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'reset' --arg 'Unit' --burn-cap 0.1

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -72,11 +72,11 @@ This tutorial uses CameLigo, but you do not need any experience with OCaml to ru
 Follow these steps to create a LIGO project:
 
 1. On the command-line terminal, create a folder for the project and open it.
-You can name your project anything you want, such as `example-smart-contract`.
+You can name your project anything you want, such as `example-smart-contract-cameligo`.
 
    ```bash
-   mkdir example-smart-contract
-   cd example-smart-contract
+   mkdir example-smart-contract-cameligo
+   cd example-smart-contract-cameligo
    ```
 
 1. Create a file named `increment.mligo` in the project folder.

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -200,71 +200,60 @@ Follow these steps to create the code for the contract:
    type storage = int
    ```
 
-1. Add this code to define the parameters that the contract accepts.
-In this case, if the client calls the increment or decrement endpoints, it must pass an integer.
-If it calls the reset endpoint, it does not pass any parameters.
+1. Add this code to define the return type for the endpoints.
+Tezos entrypoints return two values: a list of other operations to call and the new value of the contract's storage.
 
    ```ocaml
-   type parameter =
-   | Increment of int
-   | Decrement of int
-   | Reset
+   type returnValue = operation list * storage
    ```
 
-   This code is an OCaml type called a *variant*, similar to an enumeration in many other languages, but with some other features.
-
-1. Add this code to create the `main` function, which defines the entrypoints that the client can call:
-
-   ```ocaml
-   let main (action, store : parameter * storage) : operation list * storage =
-    ([] : operation list),    // No operations
-    (match action with
-    | Increment (n) -> add (store, n)
-    | Decrement (n) -> sub (store, n)
-    | Reset         -> 0)
-   ```
-
-   Tezos entrypoints return two values: a list of other operations to call and the new value of the contract's storage.
-   In this case, the contract does not call any other operations, so the first return value is an empty list of operations, denoted by the code `([] : operation list)`.
-
-   The second return value, the new value of the contract's storage, depends on which endpoint the client called:
-
-    - If the client calls the "Reset" entrypoint, the new value of the storage is 0.
-    - If the client calls the "Increment" or "Decrement" entrypoints the function passes the storage and the integer that the client sent to the `add` or `sub` functions, which you create in the next step.
-
-1. Add these functions to increment or decrement the storage:
+1. Add the code for the increment and decrement entrypoints:
 
    ```ocaml
    // Increment entrypoint
-   let add (store, inc : storage * int) : storage = store + inc
+   [@entry] let increment (delta : int) (store : storage) : returnValue =
+     [], store + delta
+
    // Decrement entrypoint
-   let sub (store, dec : storage * int) : storage = store - dec
+   [@entry] let decrement (delta : int) (store : storage) : returnValue =
+     [], store - delta
    ```
 
-   These functions receive a tuple as a parameter, which includes the current value of the storage in the `store` variable and the value that the client passed in the `inc` or `dec` variables.
-   Then return the new value of the storage based on those parameters.
+   These functions begin with the `@entry` annotation to indicate that they are entrypoints.
+   They accept two parameters: the change in the storage value (an integer) and the current value of the storage (in the `storage` type that you created earlier in the code.)
+   They return a value of the type `returnValue` that you created in the previous step.
+
+   Each function returns an empty list of other operations to call and the new value of the storage.
+
+1. Add this code for the reset entrypoint:
+
+   ```ocaml
+   // Reset entrypoint
+   [@entry] let reset (() : unit) (_ : storage) : returnValue =
+     [], 0
+   ```
+
+   This function is similar to the others, but it does not take the current value of the storage into account.
+   It always returns an empty list of operations and 0.
 
 The complete contract code looks like this:
 
 ```ocaml
 type storage = int
 
-type parameter =
-| Increment of int
-| Decrement of int
-| Reset
+type returnValue = operation list * storage
 
 // Increment entrypoint
-let add (store, inc : storage * int) : storage = store + inc
-// Decrement entrypoint
-let sub (store, dec : storage * int) : storage = store - dec
+[@entry] let increment (delta : int) (store : storage) : returnValue =
+  [], store + delta
 
-let main (action, store : parameter * storage) : operation list * storage =
- ([] : operation list),    // No operations
- (match action with
- | Increment (n) -> add (store, n)
- | Decrement (n) -> sub (store, n)
- | Reset         -> 0)
+// Decrement entrypoint
+[@entry] let decrement (delta : int) (store : storage) : returnValue =
+  [], store - delta
+
+// Reset entrypoint
+[@entry] let reset (() : unit) (_ : storage) : returnValue =
+  [], 0
 ```
 
 ## Test and compile the contract

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -326,7 +326,7 @@ Now you can call the contract from any Tezos client, including Octez.
 To increment the current storage by a certain value, call the `increment` entrypoint, as in this example:
 
 ```bash
-octez-client --wait none transfer 0 from local_wallet to my-counter --entrypoint 'increment' --arg '5' --burn-cap 0.1
+octez-client --wait none transfer 0 from $MY_TZ_ADDRESS to my-counter --entrypoint 'increment' --arg '5' --burn-cap 0.1
 ```
 
 The previous example uses the local name `my-counter`.
@@ -335,13 +335,13 @@ You can also specify the contract address.
 To decrement the current storage by a certain value, call the `decrement` entrypoint, as in this example:
 
 ```bash
-octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'decrement' --arg '6' --burn-cap 0.1
+octez-client --wait none transfer 0 from $MY_TZ_ADDRESS to my-counter --entrypoint 'decrement' --arg '6' --burn-cap 0.1
 ```
 
 Finally, to reset the current storage to zero, call the `reset` entrypoint, as in this example:
 
 ```bash
-octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'reset' --arg 'Unit' --burn-cap 0.1
+octez-client --wait none transfer 0 from $MY_TZ_ADDRESS to my-counter --entrypoint 'reset' --arg 'Unit' --burn-cap 0.1
 ```
 
 ## Summary

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -217,7 +217,7 @@ Tezos entrypoints return two values: a list of other operations to call and the 
    ```
 
    These functions begin with the `@entry` annotation to indicate that they are entrypoints.
-   They accept two parameters: the change in the storage value (an integer) and the current value of the storage (in the `storage` type that you created earlier in the code.)
+   They accept two parameters: the change in the storage value (an integer) and the current value of the storage (in the `storage` type that you created earlier in the code).
    They return a value of the type `returnValue` that you created in the previous step.
 
    Each function returns an empty list of other operations to call and the new value of the storage.

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -38,21 +38,35 @@ After you deploy the contract, you or any other user can call it through Octez o
 
 ## Prerequisites
 
-| Dependency         | Installation instructions                                                                                                                                                                                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Ligo            | Follow the _Installation_ steps in this [guide](https://ligolang.org/docs/tutorials/getting-started/?lang=cameligo#install-ligo)                                                                                                                                                |
+To run this tutorial, you need the Octez client and LIGO.
 
-{% callout type="warning" title="Note" %}
-Make sure you have **installed** the above CLI tools before getting started.
-{% /callout %}
+- To install LIGO, see <https://ligolang.org/docs/intro/installation>.
+You can verify that LIGO is installed by running this command:
 
-Now that you have installed the [_octez-client_](https://opentezos.com/tezos-basics/cli-and-rpc/#how-to-install-the-octez-client) and [_Ligo_](https://ligolang.org/docs/tutorials/getting-started/?lang=cameligo#install-ligo), we'll go ahead and dive right in.
+   ```bash
+   ligo version
+   ```
 
-Ligo is a high-level programming language created by Marigold to write smart contracts for the Tezos blockchain.
+   If you see a message with the version of LIGO you have installed, LIGO is installed correctly.
+
+- To install the Octez client, follow the instructions to install the `tezos-client` package on your system on this site: <http://tezos.gitlab.io/index.html>.
+You need only the `tezos-client` packages, not the other Octez packages such as `tezos-node`.
+
+   You can verify that the Octez client is installed by running this command:
+
+   ```bash
+   octez-client --version
+   ```
+
+   If you see a message with the version of Octez that you have installed, the Octez client is installed correctly.
+   For help on Octez, run `octez-client --help` or see <http://tezos.gitlab.io/index.html>.
+
+LIGO is a high-level programming language created by Marigold to write smart contracts for the Tezos blockchain.
 
 It abstracts away the complexity of using Michelson (the smart contract language directly available on-chain) and provides different syntaxes that make it easier to write smart contracts on Tezos.
 
-The 2 syntaxes that are available at the moment are *JsLigo*, a syntax similar to TypeScript, and *CameLigo*, a syntax similar to OCaml. The following article will introduce CameLigo.
+LIGO provides two syntaxes: *JsLigo*, a syntax similar to TypeScript, and *CameLigo*, a syntax similar to OCaml.
+This tutorial uses CameLigo, but you do not need any experience with OCaml to run it.
 
 ## Create a project folder
 
@@ -72,66 +86,6 @@ Inside the `example-smart-contract` folder, let's create a file called `incremen
 
 ```bash
 touch increment.mligo
-```
-
-## Confirm your setup
-### Ligo
-
-You can run
-```bash
-./ligo version
-```
-or
-```bash
-ligo version
-```
-according to your setup to check if Ligo is properly installed. You should see something like:
-``` sh
-Protocol built-in: lima
-0.60.0
-```
-
-### Octez-client
-
-We can check that it's correctly installed by running the following command:
-
-``` sh
-octez-client
-```
-
-And we should see something like this returned:
-
-``` sh
-Usage:
-  octez-client [global options] command [command options]
-  octez-client --help (for global options)
-  octez-client [global options] command --help (for command options)
-  octez-client --version (for version information)
-
-To browse the documentation:
-  octez-client [global options] man (for a list of commands)
-  octez-client [global options] man -v 3 (for the full manual)
-
-Global options (must come before the command):
-  -d --base-dir <path>: client data directory (absent: TEZOS_CLIENT_DIR env)
-  -c --config-file <path>: configuration file
-  -t --timings: show RPC request times
-  --chain <hash|tag>: chain on which to apply contextual commands (commands dependent on the context associated with the specified chain). Possible tags are 'main' and 'test'.
-  -b --block <hash|level|tag>: block on which to apply contextual commands (commands dependent on the context associated with the specified block). Possible tags include 'head' and 'genesis' +/- an optional offset (e.g. "octez-client -b head-1 get timestamp"). Note that block queried must exist in node's storage.
-  -w --wait <none|<int>>: how many confirmation blocks are needed before an operation is considered included
-  -p --protocol <hash>: use commands of a specific protocol
-  -l --log-requests: log all requests to the node
-  --better-errors: Error reporting is more detailed. Can be used if a call to an RPC fails or if you don't know the input accepted by the RPC. It may happen that the RPC calls take more time however.
-  -A --addr <IP addr|host>: [DEPRECATED: use --endpoint instead] IP address of the node
-  -P --port <number>: [DEPRECATED: use --endpoint instead] RPC port of the node
-  -S --tls: [DEPRECATED: use --endpoint instead] use TLS to connect to node.
-  -m --media-type <json, binary, any or default>: Sets the "media-type" value for the "accept" header for RPC requests to the node. The media accept header indicates to the node which format of data serialisation is supported. Use the value "json" for serialisation to the JSON format.
-  -E --endpoint <uri>: HTTP(S) endpoint of the node RPC interface; e.g. 'http://localhost:8732'
-  -s --sources <path>: path to JSON file containing sources for --mode light. Example file content: {"min_agreement": 1.0, "uris": ["http://localhost:8732", "https://localhost:8733"]}
-  -R --remote-signer <uri>: URI of the remote signer
-  -f --password-filename <filename>: path to the password filename
-  -M --mode <client|light|mockup|proxy>: how to interact with the node
-
 ```
 
 ## Switch to a Testnet
@@ -383,7 +337,6 @@ Finally, to reset the current storage to zero, you can call the `reset` entrypoi
 ```bash
 octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'reset' --arg 'Unit' --burn-cap 0.1
 ```
-
 
 ## Summary
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -344,6 +344,8 @@ Finally, to reset the current storage to zero, call the `reset` entrypoint, as i
 octez-client --wait none transfer 0 from $MY_TZ_ADDRESS to my-counter --entrypoint 'reset' --arg 'Unit' --burn-cap 0.1
 ```
 
+You can go back to the block explorer to verify that the storage of the contract changed.
+
 ## Summary
 
 Now the contract is running on the Tezos blockchain.

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -1,15 +1,40 @@
 ---
 id: first-smart-contract-ligo
-title: Originate your First Smart Contract with LIGO
-authors: 'John Joubert, Sasha Aldrick, Claude Barde'
-lastUpdated: 7th July 2023
+title: Deploy a smart contract with LIGO
+authors: 'John Joubert, Sasha Aldrick, Claude Barde, Tim McMackin'
+lastUpdated: 12th August 2023
 ---
 
----
+This tutorial covers using the Octez command-line client to deploy a smart contract to Tezos.
+The tutorial uses the LIGO programming language, which is one of the languages that you can write Tezos smart contracts in, but you don't need any experience with LIGO.
 
 {% callout type="note" title="Want to use SmartPy?" %}
-Click [here](/tutorials/originate-your-first-smart-contract/smartpy) to find out how to originate your first smart contract using SmartPy. 
+Click [here](/tutorials/originate-your-first-smart-contract/smartpy) to find out how to deploy a smart contract using SmartPy.
 {% /callout %}
+
+In this tutorial, you will learn how to:
+
+- Connect the Octez client to a testnet
+- Create a wallet
+- Get tokens from a faucet
+- Code a contract in LIGO, including:
+  - Defining the storage for the contract
+  - Defining endpoints in the contract
+  - Writing code to run when the endpoints are called
+- Deploy (or originate) the contract to Tezos and set its starting storage value
+- Look up the current state of the contract
+- Call the contract from the command line
+
+## Tutorial contract
+
+The contract that you deploy in this tutorial stores a single integer.
+It provides these endpoints that users can call to change the value of that integer:
+
+- The `increment` endpoint accepts an integer as a parameter and adds that integer to the value in storage
+- The `decrement` endpoint accepts an integer as a parameter and subtracts that integer to the value in storage
+- The `reset` endpoint takes no parameters and resets the value in storage to 0
+
+After you deploy the contract, you or any other user can call it through Octez or a distributed application (dApp).
 
 ## Prerequisites
 
@@ -358,3 +383,11 @@ Finally, to reset the current storage to zero, you can call the `reset` entrypoi
 ```bash
 octez-client --wait none transfer 0 from local_wallet to increment --entrypoint 'reset' --arg 'Unit' --burn-cap 0.1
 ```
+
+
+## Summary
+
+Now the contract is running on the Tezos blockchain.
+You or any other user can call it from any source that can send transactions to Tezos, including Octez, dApps, and other contracts.
+
+If you want to continue working with this contract, try creating a dApp to call it from a web application, similar to the dApp that you create in the tutorial [Build your first app on Tezos](../../build-your-first-app/).

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -8,9 +8,7 @@ lastUpdated: 13th September 2023
 This tutorial covers using the Octez command-line client to deploy a smart contract to Tezos.
 The tutorial uses the LIGO programming language, which is one of the languages that you can write Tezos smart contracts in, but you don't need any experience with LIGO.
 
-{% callout type="note" title="Want to use SmartPy?" %}
-Click [here](/tutorials/originate-your-first-smart-contract/smartpy) to find out how to deploy a smart contract using SmartPy.
-{% /callout %}
+If you are more familiar with Python, try [Originate your First Smart Contract with SmartPy](/tutorials/originate-your-first-smart-contract/smartpy).
 
 In this tutorial, you will learn how to:
 
@@ -40,7 +38,7 @@ After you deploy the contract, you or any other user can call it through Octez o
 
 To run this tutorial, you need the Octez client and LIGO.
 
-- To install LIGO, see <https://ligolang.org/docs/intro/installation>.
+- To install the LIGO programming language, see <https://ligolang.org/docs/intro/installation>.
 You can verify that LIGO is installed by running this command:
 
    ```bash
@@ -49,7 +47,7 @@ You can verify that LIGO is installed by running this command:
 
    If you see a message with the version of LIGO you have installed, LIGO is installed correctly.
 
-- To install the Octez client, follow the instructions to install the `tezos-client` package on your system on this site: <http://tezos.gitlab.io/index.html>.
+- To install the Octez client, which allows you to send transactions to the Tezos blockchain, follow the instructions to install the `tezos-client` package on your system on this site: <http://tezos.gitlab.io/index.html>.
 You need only the `tezos-client` packages, not the other Octez packages such as `tezos-node`.
 
    You can verify that the Octez client is installed by running this command:

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -2,7 +2,7 @@
 id: first-smart-contract-ligo
 title: Deploy a smart contract with LIGO
 authors: 'John Joubert, Sasha Aldrick, Claude Barde, Tim McMackin'
-lastUpdated: 12th August 2023
+lastUpdated: 13th September 2023
 ---
 
 This tutorial covers using the Octez command-line client to deploy a smart contract to Tezos.

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -282,7 +282,7 @@ Now you can deploy the contract.
 Deploying a contract to the network is called "originating."
 Originating the contract requires a small amount of Tezos tokens as a fee.
 
-1. Run the following command to originate the smart contract, changing `$MY_TZ_ADDRESS` to the address of the wallet that you created earlier in the tutorial:
+1. Run the following command to originate the smart contract, changing `$MY_TZ_ADDRESS` to the address or local name of the wallet that you created earlier in the tutorial:
 
    ```bash
    octez-client originate contract my-counter \
@@ -323,7 +323,7 @@ Originating the contract requires a small amount of Tezos tokens as a fee.
 
 Now you can call the contract from any Tezos client, including Octez.
 
-To increment the current storage by a certain value, call the `increment` entrypoint, as in this example:
+To increment the current storage by a certain value, call the `increment` entrypoint, as in this example, again changing `$MY_TZ_ADDRESS` to the address or local name of the wallet that you created earlier in the tutorial:
 
 ```bash
 octez-client --wait none transfer 0 from $MY_TZ_ADDRESS to my-counter --entrypoint 'increment' --arg '5' --burn-cap 0.1

--- a/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/ligo/index.md
@@ -6,7 +6,8 @@ lastUpdated: 13th September 2023
 ---
 
 This tutorial covers using the Octez command-line client to deploy a smart contract to Tezos.
-The tutorial uses the LIGO programming language, which is one of the languages that you can write Tezos smart contracts in, but you don't need any experience with LIGO.
+The tutorial uses the LIGO programming language, which is one of the languages that you can write Tezos smart contracts in
+Specifically, this tutorial uses the CameLIGO version of LIGO, which has syntax similar to OCaml, but you don't need any experience with OCaml or LIGO to do this tutorial.
 
 If you are more familiar with Python, try [Originate your First Smart Contract with SmartPy](/tutorials/originate-your-first-smart-contract/smartpy).
 

--- a/src/pages/tutorials/originate-your-first-smart-contract/smartpy/index.md
+++ b/src/pages/tutorials/originate-your-first-smart-contract/smartpy/index.md
@@ -1,8 +1,8 @@
 ---
 id: first-smart-contract-smartpy
-title: Originate your First Smart Contract with SmartPy
-authors: 'John Joubert, Sasha Aldrick'
-lastUpdated: 7th July 2023
+title: Deploy a smart contract with SmartPy
+authors: 'John Joubert, Sasha Aldrick, Tim McMackin'
+lastUpdated: 13th September 2023
 ---
 
 This tutorial covers using the Octez command-line client to deploy a smart contract to Tezos.
@@ -23,6 +23,36 @@ In this tutorial, you will learn how to:
 - Deploy (or originate) the contract to Tezos and set its starting storage value
 - Look up the current state of the contract
 - Call the contract from the command line
+
+## Tutorial contract
+
+The contract that you deploy in this tutorial stores a string value.
+It provides entrypoints that clients can call to change the value of that string:
+
+- The `replace` endpoint accepts a new string as a parameter and stores that string, replacing the existing string.
+- The `append` endpoint accepts a new string as a parameter and appends it to the existing string.
+
+After you deploy the contract, you or any other user can call it through Octez or a distributed application (dApp).
+
+## Prerequisites
+
+To run this tutorial, you need the Octez client, Docker, and SmartPy.
+
+- SmartPy requires Docker, so see <https://www.docker.com/> to install Docker.
+
+- To install the SmartPy programming language, see <https://smartpy.io/manual/introduction/installation>.
+
+- To install the Octez client, which allows you to send transactions to the Tezos blockchain, follow the instructions to install the `tezos-client` package on your system on this site: <http://tezos.gitlab.io/index.html>.
+You need only the `tezos-client` packages, not the other Octez packages such as `tezos-node`.
+
+   You can verify that the Octez client is installed by running this command:
+
+   ```bash
+   octez-client --version
+   ```
+
+   If you see a message with the version of Octez that you have installed, the Octez client is installed correctly.
+   For help on Octez, run `octez-client --help` or see <http://tezos.gitlab.io/index.html>.
 
 ## Tutorial contract
 


### PR DESCRIPTION
These are my suggestions for clarifying the "Originate your first smart contract tutorial." Per discussion with Tezos folks, I'm changing the contract from using a single `main` function to separate functions for each endpoint because the `main` syntax is more complicated and soon to be deprecated.