### PR TITLE
Set up styles for nested ordered lists

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -184,3 +184,12 @@ nav.navbar {
 .theme-last-updated b {
   font-weight: inherit;
 }
+
+/* Set numbering for nested lists */
+ol li ol {
+  list-style-type: lower-alpha;
+}
+
+ol li ol li ol {
+  list-style-type: lower-roman;
+}


### PR DESCRIPTION
By default, docusaurus uses list numbering like this, with items being numbered like `1.ii.c`:

<img width="274" alt="Screenshot 2023-11-06 at 9 39 59 AM" src="https://github.com/trilitech/tezos-developer-docs/assets/6494785/fcebf6ec-ba6c-4c91-82d6-def2fb34d391">

I think it's easier to read as `1.a.i` as in this example:
<img width="311" alt="Screenshot 2023-11-06 at 9 37 59 AM" src="https://github.com/trilitech/tezos-developer-docs/assets/6494785/39cbd49d-9c2c-4196-9a74-15d710584dca">
