### PR TITLE
Disable contextual search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
         apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "57d6a376a3528866784a143809cc7427",
         indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "tezosdocs",
         // Optional: see doc section below
-        contextualSearch: true,
+        contextualSearch: false,
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
         // externalUrlRegex: 'external\\.com|domain\\.com',
         // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs


### PR DESCRIPTION
Per this thread:
https://discourse.algolia.com/t/algolia-searchbar-is-not-working-with-docusaurus-v2/14659

Disabling contextual search can get algolia search working again on Docusaurus.