### PR TITLE
Fix text disappearing on hover in the search results box

### DIFF
--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -1,6 +1,7 @@
 :root {
   --docsearch-primary-color: none !important;
   --docsearch-text-color: var(--ifm-font-color-base);
+  --docsearch-hit-active-color: inherit;
 }
 
 .DocSearch-Button {


### PR DESCRIPTION
When you type a search query and hover over the results in the search box, the text turns white and disappears:
<img width="568" alt="before" src="https://github.com/trilitech/tezos-developer-docs/assets/6494785/3d85f089-0c9f-4a72-9be1-a305f6821b80">

This update makes the text appear:
<img width="563" alt="after" src="https://github.com/trilitech/tezos-developer-docs/assets/6494785/4d11be6a-ebf9-42ed-a11c-b1d0d2bd0313">
