### PR TITLE
Capitalize Smart Rollup in tutorial

### DIFF
--- a/docs/tutorials/smart-rollup.mdx
+++ b/docs/tutorials/smart-rollup.mdx
@@ -1,21 +1,21 @@
 ---
-title: Deploy a smart rollup
+title: Deploy a Smart Rollup
 last_update:
   date: 11 October 2023
 ---
 
 import LucidDiagram from '@site/src/components/LucidDiagram';
 
-This tutorial covers how to deploy a smart rollup in a Tezos sandbox.
+This tutorial covers how to deploy a Smart Rollup in a Tezos sandbox.
 To run this tutorial, you should have a basic understanding of how Tezos works and the ability to use the command-line terminal on your computer.
 
 In this tutorial, you will learn:
 
-- What a smart rollup is and how they help scale Tezos
+- What a Smart Rollup is and how they help scale Tezos
 - How information passes between Tezos and Smart Rollups
-- How to respond to messages from Tezos in a smart rollup
+- How to respond to messages from Tezos in a Smart Rollup
 
-## What is a smart rollup?
+## What is a Smart Rollup?
 
 Smart Rollups are processing units that run outside the Tezos network but communicate with Tezos on a regular basis.
 These processing units can run arbitrarily large amounts of code without waiting for Tezos baking nodes to run and verify that code.
@@ -43,7 +43,7 @@ Rollups maintain consensus by publishing the hash of their state to Tezos, which
 The specific way that rollups publish their states and maintain consensus is beyond the scope of this tutorial.
 For more information about rollups and their consensus mechanism, see [Smart Optimistic Rollups](../architecture/smart-rollups).
 
-This diagram shows a smart rollup interacting with layer 1 by receiving a message, running processing based on that message, and sending a transaction to layer 1:
+This diagram shows a Smart Rollup interacting with layer 1 by receiving a message, running processing based on that message, and sending a transaction to layer 1:
 
 <LucidDiagram width="640px" height="480px" src="https://lucid.app/documents/embedded/74fd884e-9c71-409e-b7d3-c3a871a17178" id="KYtBl2woQVuV" />
 
@@ -52,7 +52,7 @@ Each Tezos block contains a global rollups inbox that contains messages from Tez
 Anyone can add a message to this inbox and all messages are visible to all rollups.
 Rollups receive this inbox, filter it to the messages that they are interested in, and act on them accordingly.
 
-## Smart rollup analogy
+## Smart Rollup analogy
 
 Businesses talk about _horizontal scaling_ versus _vertical scaling_.
 If a business is growing and its employees are being overworked, the business could use vertical scaling to hire more employees or use better tools to improve the productivity of each employee.

--- a/docs/tutorials/smart-rollup/deploy.md
+++ b/docs/tutorials/smart-rollup/deploy.md
@@ -61,6 +61,6 @@ This command creates an address for the rollup and stores a small amount of data
    If you need to open a new terminal window within the Docker container, run the command `docker exec -it octez-container /bin/sh`.
 
    Like the command to originate a smart contract, this command uses the `--burn-cap` argument to allow the transaction to take fees from the account.
-   Also like deploying a smart contract, the response in the terminal shows information about the transaction and the address of the originated smart rollup, which starts with `sr1`.
+   Also like deploying a smart contract, the response in the terminal shows information about the transaction and the address of the originated Smart Rollup, which starts with `sr1`.
 
 Now layer 1 is aware of the rollup and nodes can run the rollup kernel.

--- a/docs/tutorials/smart-rollup/run.md
+++ b/docs/tutorials/smart-rollup/run.md
@@ -4,11 +4,11 @@ last_update:
   date: 25 October 2023
 ---
 
-Now that the smart rollup is originated on layer 1, anyone can run a smart rollup node for it.
-Smart rollup nodes are similar to baking nodes, but they run the smart rollup kernel instead of baking Tezos blocks.
-In these steps, you start a smart rollup node, but note that anyone can run a node based on your kernel, including people who want to verify the rollup's behavior.
+Now that the Smart Rollup is originated on layer 1, anyone can run a Smart Rollup node for it.
+Smart Rollup nodes are similar to baking nodes, but they run the Smart Rollup kernel instead of baking Tezos blocks.
+In these steps, you start a Smart Rollup node, but note that anyone can run a node based on your kernel, including people who want to verify the rollup's behavior.
 
-## Running a smart rollup node
+## Running a Smart Rollup node
 
 1. Copy the contents of the `preimages` folder to a folder that the rollup node can access by running these commands:
 
@@ -47,7 +47,7 @@ Now you can add messages to the inbox and see the rollup node receive and respon
    tail -f hello_kernel.debug
    ```
 
-   Now, each time a block is baked, the smart rollup node prints the contents of the messages in the smart rollup inbox, as in this example:
+   Now, each time a block is baked, the Smart Rollup node prints the contents of the messages in the Smart Rollup inbox, as in this example:
 
    ```
    # Hello, kernel!
@@ -70,7 +70,7 @@ Now you can add messages to the inbox and see the rollup node receive and respon
 
 1. Open a fourth terminal window, enter the Docker container with the command `docker exec -it octez-container /bin/sh`, and go to the `hello_world_kernel` folder.
 
-1. In this fourth terminal window, run this command to simulate adding a message to the smart rollup inbox:
+1. In this fourth terminal window, run this command to simulate adding a message to the Smart Rollup inbox:
 
    ```bash
    octez-client send smart rollup message '[ "test" ]' from "bootstrap3"
@@ -107,9 +107,9 @@ To continue your work with Smart Rollups, you can you can explore examples from 
 
 ## References
 
-- [Smart rollup documentation](https://tezos.gitlab.io/alpha/smart_rollups.html)
-- [Smart rollup kernel SDK](https://gitlab.com/tezos/tezos/-/tree/master/src/kernel_sdk)
-- [Smart rollup kernel examples](https://gitlab.com/tezos/kernel-gallery/-/tree/main/)
+- [Smart Rollup documentation](https://tezos.gitlab.io/alpha/smart_rollups.html)
+- [Smart Rollup kernel SDK](https://gitlab.com/tezos/tezos/-/tree/master/src/kernel_sdk)
+- [Smart Rollup kernel examples](https://gitlab.com/tezos/kernel-gallery/-/tree/main/)
 - [Tezos Smart Rollups resources](https://airtable.com/shrvwpb63rhHMiDg9/tbl2GNV1AZL4dkGgq)
 - [Tezos testnets](https://teztnets.xyz/)
 - [Originating the installer kernel](https://tezos.stackexchange.com/questions/4784/how-to-originating-a-smart-rollup-with-an-installer-kernel/5794#5794)


### PR DESCRIPTION
Missed these instances where "Smart Rollup" needed to be capitalized.