### PR TITLE
Clean output folder before copying contents from build output

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,5 +24,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_S3_PRODUCTION_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_S3_PRODUCTION_SECRET }}
           aws-region: eu-west-1
+      - run: aws s3 rm ${{ secrets.AWS_S3_STAGE_PATH }}/*
       - run: aws s3 sync ./build ${{ secrets.AWS_S3_PRODUCTION_PATH }}
       - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DISTRIBUTION_PRODUCTION }} --paths '/*'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,5 +24,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_S3_STAGE_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_S3_STAGE_SECRET }}
           aws-region: eu-west-1
+      - run: aws s3 rm ${{ secrets.AWS_S3_STAGE_PATH }}/*
       - run: aws s3 sync ./build ${{ secrets.AWS_S3_STAGE_PATH }}
       - run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_DISTRIBUTION_STAGE }} --paths '/*'


### PR DESCRIPTION
Old files from previous builds remain in the S3 folder, such as  this page:
https://docs.tezos.com/app-development/taquito/#wallet-setup

This PR cleans the S3 folder before copying the contents of the build output.