### PR TITLE
Serve docs at site root instead of /docs/

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,13 +27,12 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          routeBasePath: '/', // Serve the docs at the site's root
           remarkPlugins: [math],
           rehypePlugins: [katex],
           showLastUpdateTime: true,
         },
-        blog: {
-          showReadingTime: true,
-        },
+        blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },


### PR DESCRIPTION
Docs are showing up in a subdirectory /docs/, which causes problems like non-working 404 pages. 