### PR TITLE
Fix tutorial links by using the root

### DIFF
--- a/docs/tutorials.mdx
+++ b/docs/tutorials.mdx
@@ -16,7 +16,7 @@ These tutorials are intended for developers who are starting work with Tezos:
 <TutorialCard
   title="Deploy a smart contract"
   emoji="🚀"
-  href="./tutorials/smart-contract"
+  href="/tutorials/smart-contract"
   description="In 15 minutes, go from zero to hero and deploy your first smart contract with your choice of JavaScript, OCaml, or Python-like languages"
   link="Start tutorial"
   />
@@ -24,7 +24,7 @@ These tutorials are intended for developers who are starting work with Tezos:
 <TutorialCard
   title="Mint NFTs from a web app"
   emoji="💻"
-  href="./tutorials/create-an-nft/nft-web-app"
+  href="/tutorials/create-an-nft/nft-web-app"
   description="Create a web app that uses an existing contract to create NFTs"
   link="Start tutorial"
   />
@@ -40,7 +40,7 @@ These tutorials contain multiple parts and are intended for developers with some
 <TutorialCard
   title="Build your first app on Tezos"
   emoji="💡"
-  href="./tutorials/build-your-first-app/"
+  href="/tutorials/build-your-first-app/"
   description="Learn how to set up and create a decentralized web application on Tezos using TypeScript, Taquito, and Svelte"
   link="Start tutorial"
   />
@@ -48,7 +48,7 @@ These tutorials contain multiple parts and are intended for developers with some
 <TutorialCard
   title="Create a contract and web app that mints NFTs"
   emoji="📦"
-  href="./tutorials/create-an-nft/nft-taquito"
+  href="/tutorials/create-an-nft/nft-taquito"
   description="Create your own NFTs with contracts and web applications"
   link="Start tutorial"
   />
@@ -56,7 +56,7 @@ These tutorials contain multiple parts and are intended for developers with some
 <TutorialCard
   title="Create an NFT from the command line"
   emoji="⚡️"
-  href="./tutorials/create-an-nft/nft-tznft"
+  href="/tutorials/create-an-nft/nft-tznft"
   description="Learn about NFTs and how to create them from files on your computer"
   link="Start tutorial"
   />
@@ -72,7 +72,7 @@ These tutorials are intended for developers who are familiar with Tezos and want
 <TutorialCard
   title="Build an NFT marketplace"
   emoji="🛒"
-  href="./tutorials/build-an-nft-marketplace"
+  href="/tutorials/build-an-nft-marketplace"
   description="Learn how to build a marketplace to buy and sell different kinds of tokens with LIGO smart contract templates"
   link="Start tutorial"
   />
@@ -80,7 +80,7 @@ These tutorials are intended for developers who are familiar with Tezos and want
 <TutorialCard
   title="Deploy a smart rollup"
   emoji="🏎"
-  href="./tutorials/smart-rollup"
+  href="/tutorials/smart-rollup"
   description="Learn how to deploy a smart rollup to handle large amounts of processing off the main chain"
   link="Start tutorial"
   />


### PR DESCRIPTION
Using the root like this should make these links work both in dev mode and in prod builds.

Preview: https://docs-staging-git-fix-tutorial-links-trili-tech.vercel.app/tutorials