### PR TITLE
Fix languages page broken links

### DIFF
--- a/docs/smart-contracts/languages.md
+++ b/docs/smart-contracts/languages.md
@@ -7,9 +7,9 @@ last_update:
 
 You can write Tezos smart contracts in any of these languages:
 
-- [LIGO](./languages/ligo), which has versions with syntaxes similar to JavaScript/TypeScript and OCaml
-- [SmartPy](./languages/smartpy), which has a syntax similar to Python
-- [Archetype](./languages/archetype), which is a high-level language developed specifically for Tezos
+- [LIGO](./ligo), which has versions with syntaxes similar to JavaScript/TypeScript and OCaml
+- [SmartPy](./smartpy), which has a syntax similar to Python
+- [Archetype](./archetype), which is a high-level language developed specifically for Tezos
 
 Each of these languages are eventually compiled to Michelson, the base language for Tezos smart contracts.
-For information about Michelson, see [Michelson](./languages/michelson).
+For information about Michelson, see [Michelson](./michelson).


### PR DESCRIPTION
Fixes the issue: https://github.com/trilitech/tezos-developer-docs/issues/189

Updated the relative routing links in the Languages page.