### PR TITLE
FA2 requires that tokens actually transfer

### DIFF
--- a/docs/architecture/tokens.md
+++ b/docs/architecture/tokens.md
@@ -2,7 +2,7 @@
 title: Tokens
 authors: "Claude Barde, Aymeric Bethencourt, Tim McMackin"
 last_update:
-  date: 1 November 2023
+  date: 28 November 2023
 ---
 
 In a blockchain ecosystem, a digital asset that can be transferred between accounts is called a _token_.
@@ -13,7 +13,6 @@ Tezos supports many types of tokens, including:
 - Non-fungible tokens (NFTs), which are unique digital assets that can represent ownership of something
 - Stablecoins, which are tied to the price of fiat currencies such as USD and EUR
 - Wrapped tokens, which represent tokens from another blockchain or another standard; see [Wrapped tokens](#wrapped-tokens)
-- Non-transferable tokens, also known as soulbound tokens, which cannot be transferred to another account after they are created
 
 It's important to remember that in most cases, Tezos tokens are managed by smart contracts.
 Tokens are not stored directly in accounts; instead, smart contracts keep a ledger of how many tokens different accounts hold.

--- a/docs/architecture/tokens/FA2.md
+++ b/docs/architecture/tokens/FA2.md
@@ -2,7 +2,7 @@
 title: FA2 tokens
 authors: "Claude Barde, Aymeric Bethencourt, Tim McMackin"
 last_update:
-  date: 28th November 2023
+  date: 28 November 2023
 ---
 
 The FA2 standard supports several different token types, including:

--- a/docs/architecture/tokens/FA2.md
+++ b/docs/architecture/tokens/FA2.md
@@ -2,14 +2,13 @@
 title: FA2 tokens
 authors: "Claude Barde, Aymeric Bethencourt, Tim McMackin"
 last_update:
-  date: 26 October 2023
+  date: 28th November 2023
 ---
 
 The FA2 standard supports several different token types, including:
 
 - Fungible tokens
 - Non-fungible tokens (NFTs)
-- Non-transferable tokens, also known as soulbound tokens
 - Multiple types of tokens in the same contract
 
 FA2 gives developers freedom to create new types of tokens while following an interface standard that lets the tokens work with existing wallets and applications.


### PR DESCRIPTION
This PR removes mention of soulbound tokens. You could create a token type that can't be transferred, but TZIP-12 and TZIP-7 require that the tokens actually transfer when you call the transfer entrypoint, therefore they can't support soulbound tokens, so I think the smart thing to do is to remove this mention.