### PR TITLE
Show external link icon only on main content pane

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -195,7 +195,7 @@ ol li ol li ol {
 }
 
 /* icon for external links */
-a[target="_blank"]:after {
+article a[target="_blank"]:after {
   content: url("/img/external_link.svg");
   padding-left: 5px;
 }


### PR DESCRIPTION
https://github.com/trilitech/tezos-developer-docs/pull/181 added icons for external links, but it added a second icon to links that already had an external link icon, as in the links to the whitepaper in the Reference section of the sidebar. This updates the CSS to show the icon only in links in the <article> section of the page.

Before:

![Screenshot 2023-11-29 at 2 21 51 PM](https://github.com/trilitech/tezos-developer-docs/assets/6494785/057955ed-e67c-404b-974a-91bca8a0f48e)

After: 

![Screenshot 2023-11-29 at 2 22 03 PM](https://github.com/trilitech/tezos-developer-docs/assets/6494785/d9d49e30-545a-407f-a293-961ab039c5b9)
