### PR TITLE
Add list of block explorers from octez docs

### DIFF
--- a/docs/developing/information/block-explorers.md
+++ b/docs/developing/information/block-explorers.md
@@ -1,7 +1,7 @@
 ---
 title: Block Explorers
 last_update:
-  date: 10 July 2023
+  date: 22 December 2023
 ---
 
 **What is a blockchain explorer?**
@@ -35,5 +35,11 @@ Block explorers are also used by:
 
 Here are some commonly used Tezos block explorers:
 
-1. [TzStats](https://tzstats.com/)
-2. [TzKT](https://tzkt.io/)
+- [TzStats](https://tzstats.com/)
+- [TzKT](https://tzkt.io/)
+- [Arronax](https://arronax.io)
+- [Baking Bad](https://baking-bad.org)
+- [Better Call Dev](https://better-call.dev)
+- [https://explorus.io/](https://explorus.io/)
+- [Etherlink Explorer](https://explorer.etherlink.com/)
+- [https://tzflow.com/](https://tzflow.com/)

--- a/docs/developing/information/block-explorers.md
+++ b/docs/developing/information/block-explorers.md
@@ -40,6 +40,6 @@ Here are some commonly used Tezos block explorers:
 - [Arronax](https://arronax.io)
 - [Baking Bad](https://baking-bad.org)
 - [Better Call Dev](https://better-call.dev)
-- [https://explorus.io/](https://explorus.io/)
+- [Explorus](https://explorus.io/)
 - [Etherlink Explorer](https://explorer.etherlink.com/)
-- [https://tzflow.com/](https://tzflow.com/)
+- [TzFlow](https://tzflow.com/)


### PR DESCRIPTION
The Octez docs are removing a page with links to community pages. This PR pulls the list of block explorers into the Tezos docs.