### PR TITLE
Update nft-taquito tutorial to use contract without main

### DIFF
--- a/docs/tutorials/create-an-nft/nft-taquito.md
+++ b/docs/tutorials/create-an-nft/nft-taquito.md
@@ -199,46 +199,16 @@ let get_balance (p, ledger : balance_of_param * ledger) : operation =
   Tezos.transaction responses 0mutez p.callback
 ```
 
-### Main function
+### Entrypoint functions
 
-The `main` function is a special function that defines the entrypoints in the contract.
-In this case, it accepts the entrypoint that the transaction sender called and the current state of the contract's storage.
-Then the function branches based on the entrypoint.
-
-For example, if the sender calls the `balance_of` entrypoint, the function calls the `get_balance` function and passes the parameters that the sender passed and the current state of the contract's ledger:
+Each entrypoint in the contract is a function with the `@entry` annotation.
+For example, the `mint` entrypoint calls an internal function to handle minting tokens based on the parameters that are defined in the `mint_params` type:
 
 ```ocaml
-  | Balance_of p ->
-    let op = get_balance (p, storage.ledger) in
-    [op], storage
-```
-
-Here is the complete code of the `main` function:
-
-```ocaml
-let main (param, storage : fa2_entry_points * nft_token_storage)
-    : (operation  list) * nft_token_storage =
-  match param with
-  | Transfer txs ->
-    let (new_ledger, new_reverse_ledger) = transfer
-      (txs, default_operator_validator, storage.operators, storage.ledger, storage.reverse_ledger) in
-    let new_storage = { storage with ledger = new_ledger; reverse_ledger = new_reverse_ledger } in
-    ([] : operation list), new_storage
-
-  | Balance_of p ->
-    let op = get_balance (p, storage.ledger) in
-    [op], storage
-
-  | Update_operators updates ->
-    let new_ops = fa2_update_operators (updates, storage.operators) in
-    let new_storage = { storage with operators = new_ops; } in
-    ([] : operation list), new_storage
-
-  | Mint p ->
+(** Mint NFT entrypoint *)
+[@entry]
+let mint (p : mint_params) (storage : nft_token_storage) : returnValue =
     ([]: operation list), mint (p, storage)
-
-  | Burn p ->
-    ([]: operation list), burn (p, storage)
 ```
 
 ### Initial storage state

--- a/docs/tutorials/create-an-nft/nft-taquito.md
+++ b/docs/tutorials/create-an-nft/nft-taquito.md
@@ -281,6 +281,14 @@ The IDE opens a blank contract file and shows commands for the file on the left-
 1. Paste the contents of the `contract/NFTS_contract.mligo` file into the editor.
 The IDE saves the file automatically.
 
+1. Remove the module name:
+
+   1. Click **Project Settings**.
+
+   1. Clear the **Module name (optional)** field.
+
+   1. Close the Project Settings window.
+
 1. Click **Compile** and then in the "Compile" window, click **Compile**.
 The IDE compiles the contract code to Michelson, the base language that all Tezos contracts use.
 At the bottom of the window, it prints the message `wrote output to .workspaces/NFT tutorial/build/contracts/Contract.tz`.

--- a/docs/tutorials/create-an-nft/nft-taquito.md
+++ b/docs/tutorials/create-an-nft/nft-taquito.md
@@ -166,18 +166,6 @@ type transfer =
 }
 ```
 
-The type `fa2_entry_points` is a special type that the contract's `main` function uses to define the entrypoints.
-It maps the entry points to the type of parameter that they accept:
-
-```ocaml
-type fa2_entry_points =
-  | Transfer of transfer list
-  | Balance_of of balance_of_param
-  | Update_operators of update_operator list
-  | Mint of mint_params
-  | Burn of token_id
-```
-
 ### Error messages
 
 The contract defines a series of error messages, and comments in the code describe what each error message means.


### PR DESCRIPTION
https://github.com/trilitech/tutorial-applications/issues/6 alerted me to the fact that the contract was updated to not use `main` but the tutorial was not. This PR updates the tutorial.