### PR TITLE
Remove Oxhead Alpha

### DIFF
--- a/docs/architecture/tokens/FA2.md
+++ b/docs/architecture/tokens/FA2.md
@@ -2,7 +2,7 @@
 title: FA2 tokens
 authors: "Claude Barde, Aymeric Bethencourt, Tim McMackin"
 last_update:
-  date: 28 November 2023
+  date: 29 December 2023
 ---
 
 The FA2 standard supports several different token types, including:
@@ -18,6 +18,10 @@ Because a single FA2 contract can define multiple types of tokens, each token ty
 If the contract has only one type of token, its ID must be 0, but if it has multiple types of tokens, the IDs can be any value.
 
 For the full details of the FA2 standard, see [Tezos Improvement Proposal 12 (TZIP-12)](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-12/tzip-12.md), which defines the standard.
+
+## Examples
+
+For examples of FA2 contracts, see [Sample smart contracts](../../smart-contracts/samples).
 
 ## Metadata
 

--- a/docs/developing/testnets.md
+++ b/docs/developing/testnets.md
@@ -2,11 +2,11 @@
 title: Using sandboxes and testnets
 authors: 'Mathias Hiron, Nomadic Labs, Tim McMackin, TriliTech'
 last_update:
-  date: 18 October 2023
+  date: 29 December 2023
 ---
 
 :::note
-The Tezos testnets are overseen and coordinated by [Oxhead Alpha](https://oxheadalpha.com/). The current testnets and a description of what each is used for are listed at https://teztnets.xyz/.
+The current testnets and a description of what each is used for are listed at https://teztnets.xyz/.
 :::
 
 ## Testing without a node
@@ -43,7 +43,7 @@ _Permanent test networks_ are networks that are meant to run indefinitely. In pa
 
 For the `Ghostnet` permanent network, the governance is controlled by a single entity that manages the network, with a special upgrade mechanism.
 
-At the moment, the main such network is `Ghostnet`. It follows the currently active protocol on `Mainnet`, and upgrades to the next protocol during the Adoption period on `Mainnet`. That is, after the last round of voting and before it activates on `Mainnet`. The objective is to provide a rehearsal event for `Mainnet` migration. This process is controlled by the Oxhead Alpha team.
+At the moment, the main such network is `Ghostnet`. It follows the currently active protocol on `Mainnet`, and upgrades to the next protocol during the Adoption period on `Mainnet`. That is, after the last round of voting and before it activates on `Mainnet`. The objective is to provide a rehearsal event for `Mainnet` migration.
 
 For developers, using a permanent network like `Ghostnet` is convenient compared to other public networks, as it makes it possible to keep contracts running for a long time without having to deal with the trouble of setting things up on a new network when the previous one gets shut down. Services such as indexers, explorers, or public nodes also tend to keep running more reliably on `Ghostnet` than on non-permanent networks.
 
@@ -63,7 +63,7 @@ can request some tokens from the [Ghostnet faucet](https://faucet.ghostnet.teztn
 
 _Protocol test networks_ are networks that are created specifically for a given version of the protocol.
 
-When an amendment is proposed, a corresponding network is usually created by the Oxhead Alpha team. This network gets joined by more bakers as the proposal is selected and moves through the different periods of the self-amendment process. If the protocol passes the 3 votes of the amendment, joining a test protocol early gives you about 2.5 months to test all the changes that will be made to Mainnet. If the protocol is not adopted, it usually gets discarded. Otherwise, it remains active until a different protocol is adopted.
+When an amendment is proposed, a corresponding network is created. This network gets joined by more bakers as the proposal is selected and moves through the different periods of the self-amendment process. If the protocol passes the 3 votes of the amendment, joining a test protocol early gives you about 2.5 months to test all the changes that will be made to Mainnet. If the protocol is not adopted, it usually gets discarded. Otherwise, it remains active until a different protocol is adopted.
 
 This means there is usually one or two such running networks: one for the current version of the protocol running on `Mainnet`, and possibly one for the proposed protocol that is going through the amendment process, if there is one.
 
@@ -93,7 +93,7 @@ The two periodic protocols currently are `Mondaynet` and `Dailynet`.
 
 ### Public nodes and faucets
 
-To connect to existing public nodes for these networks, or to get some testnet-only tez on these from a faucet, check [https://teztnets.xyz](https://teztnets.xyz/). The faucets and infrastructure for deploying test networks are maintained by [Oxhead Alpha](https://www.oxheadalpha.com/).
+To connect to existing public nodes for these networks, or to get some testnet-only tez on these from a faucet, check [https://teztnets.xyz](https://teztnets.xyz/).
 
 Other sources of public nodes include:
 

--- a/docs/smart-contracts/samples.md
+++ b/docs/smart-contracts/samples.md
@@ -2,7 +2,7 @@
 title: Sample smart contracts
 author: "Tim McMackin"
 last_update:
-  date: 26 December 2023
+  date: 29 December 2023
 ---
 
 Here are some places to find sample smart contacts:
@@ -12,3 +12,8 @@ Here are some places to find sample smart contacts:
 - For examples of contracts in LIGO, see https://packages.ligolang.org/contracts
 - For examples of contracts in Archetype, see https://archetype-lang.org/docs/templates/overview
 - For examples of contracts in SmartPy, see https://smartpy.io/guides/examples/
+
+For examples of FA2 smart contracts, see:
+
+- The SmartPy [FA2 library](https://smartpy.io/guides/FA2-lib/overview)
+- [oxheadalpha/smart-contracts](https://github.com/oxheadalpha/smart-contracts)

--- a/docs/tutorials/create-an-nft/nft-taquito.md
+++ b/docs/tutorials/create-an-nft/nft-taquito.md
@@ -123,7 +123,6 @@ The FA2 standard creates a framework for how tokens behave on Tezos, including f
 It provides a standard API to transfer tokens, check token balances, manage operators (addresses that are permitted to transfer tokens on behalf of the token owner), and manage token metadata.
 
 The full details of the smart contract are beyond the scope of this tutorial, but the major parts of the contract have descriptions in comments.
-For more examples of smart contracts, see [oxheadalpha/smart-contracts](https://github.com/oxheadalpha/smart-contracts) on GitHub.
 
 ### Contract entrypoints
 


### PR DESCRIPTION
The relationship between the Tezos Foundation and Oxhead Alpha is ending. Remove references to OA.

Is it still OK to link to their example FA2 contracts at https://github.com/oxheadalpha/smart-contracts? I guess we can keep linking there until they remove the repo.