### PR TITLE
Remove quotes from CSP header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,8 +7,8 @@ const katex = require('rehype-katex');
 // script-src causes development builds to fail
 // But unsafe-eval should NOT be in production builds
 const scriptSrc = process.env.NODE_ENV === 'development' ?
-  `'self' 'unsafe-inline' 'unsafe-eval' https://*.googletagmanager.com;`
-  : `'self' 'unsafe-inline' https://*.googletagmanager.com;`;
+  `self unsafe-inline unsafe-eval https://*.googletagmanager.com;`
+  : `self unsafe-inline https://*.googletagmanager.com;`;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -35,16 +35,16 @@ const config = {
       attributes: {
         'http-equiv': 'Content-Security-Policy',
       content: `
-        default-src 'none';
-        base-uri 'self';
-        manifest-src 'self';
+        default-src none;
+        base-uri self;
+        manifest-src self;
         script-src ${scriptSrc}
-        style-src 'self' 'unsafe-inline';
-        font-src 'self';
-        img-src 'self' https://*.googletagmanager.com https://*.google-analytics.com data:;
-        media-src 'self';
-        form-action 'self';
-        connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com;
+        style-src self unsafe-inline;
+        font-src self;
+        img-src self https://*.googletagmanager.com https://*.google-analytics.com data:;
+        media-src self;
+        form-action self;
+        connect-src self https://*.algolia.net https://*.algolianet.com https://*.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com;
         frame-src https://tezosbot.vercel.app https://calendly.com/ lucid.app;
         `,
       },


### PR DESCRIPTION
Docusaurus is html-encoding these quotes and it's breaking them. Removing the quotes until I can work out how to not escape them.