### PR TITLE
Enable contextual search

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,124 @@ To run tests locally, run `npm run test -- --filesToCheck=docs/developing.md,doc
 
 Docusaurus automatically checks for broken links and markdown-encoded images when you run `npm run build`.
 
+## Search
+
+Search on the site is powered by Algolia Docsearch.
+The index is in the [Algolia dashboard](https://dashboard.algolia.com/apps/QRIAHGML9Q/dashboard).
+Contextual search is enabled according to the [Docusaurus instructions](https://docusaurus.io/docs/search#using-algolia-docsearch), although the site does not currently use contextual search to separate searches by version, language, or other similar factors.
+
+The search uses [this crawler](https://crawler.algolia.com/admin/crawlers/eaa2c548-8b82-493b-8ab8-0c37e2e5d5cc/configuration/edit) to index the site:
+
+```js
+new Crawler({
+  rateLimit: 8,
+  maxDepth: 10,
+  maxUrls: 5000,
+  startUrls: ["https://docs.tezos.com/"],
+  sitemaps: ["https://docs.tezos.com/sitemap.xml"],
+  renderJavaScript: false,
+  ignoreCanonicalTo: true,
+  ignoreQueryParams: ["source", "utm_*"],
+  discoveryPatterns: ["https://docs.tezos.com/**"],
+  schedule: "every 24 hours",
+  appId: "QRIAHGML9Q",
+  apiKey: "API_KEY_GOES_HERE",
+  actions: [
+    {
+      indexName: "tezosdocs",
+      pathsToMatch: ["https://docs.tezos.com/**"],
+      recordExtractor: ({ $, helpers }) => {
+        // priority order: deepest active sub list header -> navbar active item -> 'Documentation'
+        const lvl0 =
+          $(
+            ".menu__link.menu__link--sublist.menu__link--active, .navbar__item.navbar__link--active",
+          )
+            .last()
+            .text() || "Documentation";
+
+        return helpers.docsearch({
+          recordProps: {
+            lvl0: {
+              selectors: "",
+              defaultValue: lvl0,
+            },
+            lvl1: ["header h1", "article h1"],
+            lvl2: "article h2",
+            lvl3: "article h3",
+            lvl4: "article h4",
+            lvl5: "article h5, article td:first-child",
+            lvl6: "article h6",
+            content: "article p, article li, article td:last-child",
+          },
+          indexHeadings: true,
+          aggregateContent: true,
+          recordVersion: "v3",
+        });
+      },
+    },
+  ],
+  initialIndexSettings: {
+    tezosdocs: {
+      attributesForFaceting: [
+        "type",
+        "lang",
+        "language",
+        "version",
+        "docusaurus_tag",
+      ],
+      attributesToRetrieve: [
+        "hierarchy",
+        "content",
+        "anchor",
+        "url",
+        "url_without_anchor",
+        "type",
+      ],
+      attributesToHighlight: ["hierarchy", "content"],
+      attributesToSnippet: ["content:10"],
+      camelCaseAttributes: ["hierarchy", "content"],
+      searchableAttributes: [
+        "unordered(hierarchy.lvl0)",
+        "unordered(hierarchy.lvl1)",
+        "unordered(hierarchy.lvl2)",
+        "unordered(hierarchy.lvl3)",
+        "unordered(hierarchy.lvl4)",
+        "unordered(hierarchy.lvl5)",
+        "unordered(hierarchy.lvl6)",
+        "content",
+      ],
+      distinct: true,
+      attributeForDistinct: "url",
+      customRanking: [
+        "desc(weight.pageRank)",
+        "desc(weight.level)",
+        "asc(weight.position)",
+      ],
+      ranking: [
+        "words",
+        "filters",
+        "typo",
+        "attribute",
+        "proximity",
+        "exact",
+        "custom",
+      ],
+      highlightPreTag: '<span class="algolia-docsearch-suggestion--highlight">',
+      highlightPostTag: "</span>",
+      minWordSizefor1Typo: 3,
+      minWordSizefor2Typos: 7,
+      allowTyposOnNumericTokens: false,
+      minProximity: 1,
+      ignorePlurals: true,
+      advancedSyntax: true,
+      attributeCriteriaComputedByMinProximity: true,
+      removeWordsIfNoResults: "allOptional",
+      separatorsToIndex: "_",
+    },
+  },
+});
+```
+
 ## License
 
 This project is open for contribution but the source code itself uses a commercial template and is therefore not licensed under any open-source license. Forking this project as a base for your own projects is not permitted under the license of the original template.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,10 +137,10 @@ const config = {
       },
       algolia: {
         // The application ID provided by Algolia
-        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "QPBQ67WNIG",
+        appId: "QPBQ67WNIG",
         // Public API key: it is safe to commit it
-        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "cd621124ed2d83249bf003f4a69f391c",
-        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "crawler_tezos-test",
+        apiKey: "cd621124ed2d83249bf003f4a69f391c",
+        indexName: "crawler_tezos-test",
         // Optional: see doc section below
         contextualSearch: true,
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,10 +137,10 @@ const config = {
       },
       algolia: {
         // The application ID provided by Algolia
-        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "QRIAHGML9Q",
+        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "QPBQ67WNIG",
         // Public API key: it is safe to commit it
-        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "57d6a376a3528866784a143809cc7427",
-        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "tezosdocs",
+        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "cd621124ed2d83249bf003f4a69f391c",
+        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "crawler_tezos-test",
         // Optional: see doc section below
         contextualSearch: true,
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,10 +137,10 @@ const config = {
       },
       algolia: {
         // The application ID provided by Algolia
-        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "QPBQ67WNIG",
+        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "QRIAHGML9Q",
         // Public API key: it is safe to commit it
-        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "cd621124ed2d83249bf003f4a69f391c",
-        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "crawler_tezos-test",
+        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "57d6a376a3528866784a143809cc7427",
+        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "tezosdocs",
         // Optional: see doc section below
         contextualSearch: true,
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,10 +137,10 @@ const config = {
       },
       algolia: {
         // The application ID provided by Algolia
-        appId: "QPBQ67WNIG",
+        appId: process.env.NEXT_PUBLIC_DOCSEARCH_APP_ID || "QPBQ67WNIG",
         // Public API key: it is safe to commit it
-        apiKey: "cd621124ed2d83249bf003f4a69f391c",
-        indexName: "crawler_tezos-test",
+        apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "cd621124ed2d83249bf003f4a69f391c",
+        indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "crawler_tezos-test",
         // Optional: see doc section below
         contextualSearch: true,
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,7 +142,7 @@ const config = {
         apiKey: process.env.NEXT_PUBLIC_DOCSEARCH_API_KEY || "57d6a376a3528866784a143809cc7427",
         indexName: process.env.NEXT_PUBLIC_DOCSEARCH_INDEX_NAME || "tezosdocs",
         // Optional: see doc section below
-        contextualSearch: false,
+        contextualSearch: true,
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
         // externalUrlRegex: 'external\\.com|domain\\.com',
         // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs


### PR DESCRIPTION
Contextual search should be enabled to future-proof the site if we ever offer it in multiple languages or versions. I've verified  that the search works on the staging build based on changes to the crawler. Thanks for the folks at Algolia Docsearch for helping me get the crawler working.