### PR TITLE
Remove quickstart TODOs and stubs

### DIFF
--- a/docs/dApps/quickstart.md
+++ b/docs/dApps/quickstart.md
@@ -1,5 +1,0 @@
-# dApp quickstart
-
-Here we insert the tutorial that shows how to build a react dapp on top of the contract we built in the "first smart contract" guide
-
-Mention Beacon, diagram about key custody, dapp is never concerned about keys

--- a/docs/smart-contracts/quickstart.md
+++ b/docs/smart-contracts/quickstart.md
@@ -1,5 +1,0 @@
-# Quickstart
-
-Really this should be a link to a tutorial and not duplicated information.
-
-A very basic contract in smartpy (no choice here), just so that they practice and get a feeling. They then deploy it with octez and interact with it Part of one of the tutorials

--- a/sidebars.js
+++ b/sidebars.js
@@ -12,7 +12,6 @@ const sidebars = {
       items: [
         'overview/tezos-different',
         'overview/resources',
-        // 'overview/quickstart', // TODO
         'overview/common-applications',
         'overview/glossary',
       ],
@@ -119,7 +118,6 @@ const sidebars = {
         type: 'doc',
       },
       items: [
-        // 'smart-contracts/quickstart',  // TODO
         'smart-contracts/samples',
         {
           type: 'category',


### PR DESCRIPTION
Based on discussion in https://github.com/trilitech/tezos-developer-docs/pull/219, we're not going to provide dApp or smart contract quickstarts because it would just be a rehash of the beginner tutorials.