### PR TITLE
Adjust support page

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -11,9 +11,9 @@ const sidebars = {
       },
       items: [
         'overview/tezos-different',
-        'overview/resources',
         'overview/common-applications',
         'overview/glossary',
+        'overview/resources',
       ],
     },
     {


### PR DESCRIPTION
The recently merged Support page is misplaced in the left menu, as it breaks the flow.