### PR TITLE
Mention RPC endpoints for protocol

### DIFF
--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -2,7 +2,7 @@
 title: The RPC protocol
 authors: "Tim McMackin"
 last_update:
-  date: 6 November 2023
+  date: 6 February 2023
 ---
 
 The Tezos RPC (Remote Procedure Call) protocol is a specification for a REST API that clients use to interact with Tezos nodes and nodes use to communicate with each other.
@@ -11,7 +11,10 @@ Tezos nodes act as servers and accept HTTP requests from clients and other nodes
 
 Tezos RPC uses JSON to send and receive data, but it does not adhere to the JSON-RPC specification.
 
-For a list of the endpoints in the Tezos RPC protocol, see [Shell RPCs - Reference](https://tezos.gitlab.io/shell/rpc.html#rpc-index-shell) in the Octez documentation.
+Different parts of the protocol provide different RPC endpoints:
+
+- For RPC endpoints for the shell, see [Shell RPCs - Reference](https://tezos.gitlab.io/shell/rpc.html#rpc-index-shell) in the Octez documentation.
+- For RPC endpoints for the active version of the protocol, see https://tezos.gitlab.io/active/rpc.html.
 
 ## Public and private RPC nodes
 

--- a/docs/architecture/rpc.md
+++ b/docs/architecture/rpc.md
@@ -11,7 +11,7 @@ Tezos nodes act as servers and accept HTTP requests from clients and other nodes
 
 Tezos RPC uses JSON to send and receive data, but it does not adhere to the JSON-RPC specification.
 
-Different parts of the protocol provide different RPC endpoints:
+Different parts of the software provide different RPC endpoints:
 
 - For RPC endpoints for the shell, see [Shell RPCs - Reference](https://tezos.gitlab.io/shell/rpc.html#rpc-index-shell) in the Octez documentation.
 - For RPC endpoints for the active version of the protocol, see https://tezos.gitlab.io/active/rpc.html.


### PR DESCRIPTION
This page mentions the shell RPC endpoints but not the protocol RPC endpoints. This PR adds a link to the protocol RPC info on tezos.gitlab.io.