### PR TITLE
Update SmartPy examples for SmartPy 19.0

### DIFF
--- a/docs/developing/testing.md
+++ b/docs/developing/testing.md
@@ -38,10 +38,10 @@ The following SmartPy test code snippet is for a Tezos smart contract that acts 
 ```bash
 if "templates" not in __name__:
 
-    @sp.add_test(name="Calculator")
+    @sp.add_test()
     def test():
         c1 = main.Calculator()
-        scenario = sp.test_scenario(main)
+        scenario = sp.test_scenario("Calculator")
         scenario.h1("Calculator")
         scenario += c1
         c1.multiply(x=2, y=5)

--- a/docs/smart-contracts/events.md
+++ b/docs/smart-contracts/events.md
@@ -72,10 +72,10 @@ def main():
 
 if "templates" not in __name__:
 
-    @sp.add_test(name="Events")
+    @sp.add_test()
     def test():
         c1 = main.Events(12)
-        scenario = sp.test_scenario(main)
+        scenario = sp.test_scenario("Events", main)
         scenario.h1("Add")
         scenario += c1
         c1.add(2).run(

--- a/docs/smart-contracts/languages/smartpy.mdx
+++ b/docs/smart-contracts/languages/smartpy.mdx
@@ -108,10 +108,10 @@ class Raffle(sp.Contract):
     def open_raffle(self):
         pass
 
-    @sp.add_test(name = "Raffle")
+    @sp.add_test()
     def test():
         r = Raffle()
-        scenario = sp.test_scenario()
+        scenario = sp.test_scenario("Raffle")
         scenario.h1("Raffle")
         scenario += r
 ```
@@ -199,7 +199,7 @@ class Raffle(sp.Contract):
         alice = sp.test_account("Alice")
         admin = sp.test_account("Administrator")
         r = Raffle(admin.address)
-        scenario = sp.test_scenario()
+        scenario = sp.test_scenario("Raffle")
         scenario.h1("Raffle")
         scenario += r
 
@@ -346,12 +346,12 @@ On _SmartPy_, a test is a method of the contract class, preceded by `@sp.add_tes
 Inside this method, you need to instantiate your contract class and your scenarios, to which you will add the contract instance and all the related calls that you want to test. For instance:
 
 ```python
-@sp.add_test(name="Raffle")
+@sp.add_test()
 def test():
     alice = sp.test_account("Alice")
     admin = sp.test_account("Administrator")
     r = Raffle(admin.address)
-    scenario = sp.test_scenario()
+    scenario = sp.test_scenario("Raffle")
     scenario.h1("Raffle")
     scenario += r
 ```
@@ -560,14 +560,14 @@ class Raffle(sp.Contract):
         self.data.sold_tickets[ticket_id] = current_player
 
 
-    @sp.add_test(name="Raffle")
+    @sp.add_test()
     def test():
         alice = sp.test_account("Alice")
         jack = sp.test_account("Jack")
         admin = sp.test_account("Administrator")
 
         r = Raffle(admin.address)
-        scenario = sp.test_scenario()
+        scenario = sp.test_scenario("Raffle")
         scenario.h1("Raffle")
         scenario += r
 
@@ -774,13 +774,13 @@ class Raffle(sp.Contract):
         self.data.sold_tickets = sp.map()
         self.data.raffle_is_open = False
 
-    @sp.add_test(name="Raffle")
+    @sp.add_test()
     def test():
         alice = sp.test_account("Alice")
         jack = sp.test_account("Jack")
         admin = sp.test_account("Administrator")
         r = Raffle(admin.address)
-        scenario = sp.test_scenario()
+        scenario = sp.test_scenario("Raffle")
         scenario.h1("Raffle")
         scenario += r
 

--- a/docs/tutorials/smart-contract/smartpy.mdx
+++ b/docs/tutorials/smart-contract/smartpy.mdx
@@ -139,16 +139,21 @@ You can work with SmartPy code in any IDE, but this online IDE keeps you from ha
 1. Add this code, which creates automated tests:
 
    ```python
-   @sp.add_test(name = "StoreGreeting")
+   # Automated tests that run on compilation
+   @sp.add_test()
    def test():
-       scenario = sp.test_scenario(main)
+       # Initialize the test scenario
+       scenario = sp.test_scenario("StoreGreeting", main)
        scenario.h1("StoreGreeting")
 
+       # Initialize the contract and pass the starting value
        contract = main.StoreGreeting("Hello")
        scenario += contract
 
+       # Verify that the value in storage was set correctly
        scenario.verify(contract.data.greeting == "Hello")
 
+       # Test the entrypoints and check the new storage value
        contract.replace(text = "Hi")
        contract.append(text = ", there!")
        scenario.verify(contract.data.greeting == "Hi, there!")
@@ -180,16 +185,21 @@ def main():
         def append(self, params):
             self.data.greeting += params.text
 
-@sp.add_test(name = "StoreGreeting")
+# Automated tests that run on compilation
+@sp.add_test()
 def test():
-    scenario = sp.test_scenario(main)
+    # Initialize the test scenario
+    scenario = sp.test_scenario("Test scenario", main)
     scenario.h1("StoreGreeting")
 
+    # Initialize the contract and pass the starting value
     contract = main.StoreGreeting("Hello")
     scenario += contract
 
+    # Verify that the value in storage was set correctly
     scenario.verify(contract.data.greeting == "Hello")
 
+    # Test the entrypoints and check the new storage value
     contract.replace(text = "Hi")
     contract.append(text = ", there!")
     scenario.verify(contract.data.greeting == "Hi, there!")

--- a/docs/tutorials/smart-contract/smartpy.mdx
+++ b/docs/tutorials/smart-contract/smartpy.mdx
@@ -115,6 +115,9 @@ You can work with SmartPy code in any IDE, but this online IDE keeps you from ha
    def main():
        class StoreGreeting(sp.Contract):
            def __init__(self, greeting): # Note the indentation
+               # Initialize the storage with a string passed at deployment time
+               # Cast the greeting parameter to a string
+               sp.cast(greeting, sp.string)
                self.data.greeting = greeting
 
            @sp.entrypoint # Note the indentation
@@ -175,6 +178,9 @@ import smartpy as sp
 def main():
     class StoreGreeting(sp.Contract):
         def __init__(self, greeting): # Note the indentation
+            # Initialize the storage with a string passed at deployment time
+            # Cast the greeting parameter to a string
+            sp.cast(greeting, sp.string)
             self.data.greeting = greeting
 
         @sp.entrypoint # Note the indentation


### PR DESCRIPTION
- `@sp.add_test()` no longer takes a parameter; instead, the secenario name/output folder goes on `sp.test_scenario()`
- StoreGreeting example contract now requires a cast call for some reason