### PR TITLE
Correct token off chain views

### DIFF
--- a/docs/architecture/tokens/FA1.2.md
+++ b/docs/architecture/tokens/FA1.2.md
@@ -2,7 +2,7 @@
 title: FA1.2 tokens
 authors: "Claude Barde, Aymeric Bethencourt, Tim McMackin"
 last_update:
-  date: 26 October 2023
+  date: 22 February 2024
 ---
 
 The FA1.2 standard is for _fungible tokens_, which are collections of identical, interchangeable tokens.
@@ -11,7 +11,7 @@ Commonly used FA1.2 tokens include kUSD and Ctez.
 
 Contracts that follow this standard keep a ledger that records how many tokens different accounts own.
 They have entrypoints that allow users to transfer tokens and limit the amount that can be transferred.
-They also have views that provide information such as the total amount of tokens and the amount of tokens that a specified account owns.
+They also have entrypoints that provide information such as the total amount of tokens and the amount of tokens that a specified account owns.
 
 For the full details of the FA1.2 standard, see [Tezos Improvement Proposal 7 (TZIP-7)](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-7/tzip-7.md), which defines the standard.
 
@@ -55,7 +55,7 @@ FA1.2 contracts must have these entrypoints:
   The transaction sender must be an address that has been authorized to transfer the tokens via the `approve` endpoint, even if the transaction sender and address that owns the tokens is the same address.
   After the transfer, the sender's allowance is decrease by the amount of tokens transferred.
 
-FA1.2 contracts must also have entrypoints that behave like views but run on the chain.
+FA1.2 contracts must also have entrypoints that provide information to other smart contracts.
 These entrypoints accept a contract address as a parameter and send a callback transaction to that address with information about the current state of the contract.
 They must not change the storage or generate any operations other than the callback transaction.
 

--- a/docs/architecture/tokens/FA2.md
+++ b/docs/architecture/tokens/FA2.md
@@ -2,7 +2,7 @@
 title: FA2 tokens
 authors: "Claude Barde, Aymeric Bethencourt, Tim McMackin"
 last_update:
-  date: 29 December 2023
+  date: 22 February 2024
 ---
 
 The FA2 standard supports several different token types, including:
@@ -59,19 +59,6 @@ The standard defines what happens when these entrypoints are called, the format 
 For information about these requirements, see [TZIP-12](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-12/tzip-12.md).
 
 FA1.2 contracts can add any other entrypoints in addition to the required entrypoints.
-
-## Views
-
-FA2 contracts are not required to have any views, but the specification suggests these optional views.
-If any of them are implemented, all of them should be implemented, and they should be implemented with the parameters, return values, and behaviors that are defined in the standard:
-
-- `get_balance`: Returns the amount of tokens that a specified owner owns of the specified token ID
-- `total_supply`: Returns the total number of tokens of the specified token ID
-- `all_tokens`: Returns the list of all token IDs in the contract
-- `is_operator`: Returns true if the specified address is an operator for the specified token ID and owner address
-- `token_metadata`: Returns the metadata for the specified token ID
-
-FA1.2 contracts can add any other views in addition to the required views.
 
 ## Errors
 

--- a/docs/architecture/tokens/FA2.md
+++ b/docs/architecture/tokens/FA2.md
@@ -58,7 +58,7 @@ Its parameters are a list of commands to add or remove operators for token owner
 The standard defines what happens when these entrypoints are called, the format of their parameters, and the errors that they create.
 For information about these requirements, see [TZIP-12](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-12/tzip-12.md).
 
-FA1.2 contracts can add any other entrypoints in addition to the required entrypoints.
+FA2 contracts can add any other entrypoints in addition to the required entrypoints.
 
 ## Errors
 


### PR DESCRIPTION
I was wrong to talk about the recommended views of FA2 contracts; they are off-chain views as described here:
https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-12/tzip-12.md#off-chain-views

This PR removes references to the views of FA2 contracts.