### PR TITLE
No need to configure the client so early

### DIFF
--- a/docs/tutorials/join-dal-baker/get-octez.md
+++ b/docs/tutorials/join-dal-baker/get-octez.md
@@ -2,7 +2,7 @@
 title: "Step 1: Get a Weeklynet-compatible Octez version"
 authors: Tezos core developers
 last_update:
-  date: 14 February 2024
+  date: 28 February 2024
 ---
 
 The Weeklynet test network restarts every Wednesday at 0h UTC, and for most of its lifetime (from level 512) it runs a development version of the Tezos protocol, called Alpha, which is not part of any released version of Octez.
@@ -31,22 +31,5 @@ For example, the command to start a Docker image for the Weeklynet launched on J
 
    The specific command is on the Weeklynet page at https://teztnets.com/weeklynet-about.
 
-1. Copy the URL of the public RPC endpoint for Weeklynet, such as `https://rpc.weeklynet-2024-01-17.teztnets.com`.
-This endpoint also changes each time the network is reset.
-
-1. Initialize the Octez client with that endpoint, as in this example:
-
-   ```bash
-   octez-client -E https://rpc.weeklynet-2024-01-17.teztnets.com config init
-   ```
-
-1. Optional: Hide the network warning message by running this command:
-
-   ```bash
-   export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=y
-   ```
-
-   This command suppresses the message that your instance of the Octez client is not using Mainnet.
-
-Now you have the Octez client and node configured to work with Weeklynet.
-The next step is to start an Octez node; continue to [Step 2: Run an Octez node on Weeklynet](./run-node).
+Now you have the Octez node configured to work with Weeklynet.
+The next step is to start the Octez node; continue to [Step 2: Run an Octez node on Weeklynet](./run-node).

--- a/docs/tutorials/join-dal-baker/prepare-account.md
+++ b/docs/tutorials/join-dal-baker/prepare-account.md
@@ -2,32 +2,17 @@
 title: "Step 3: Set up a baker account on Weeklynet"
 authors: Tezos core developers
 last_update:
-  date: 28 February 2024
+  date: 6 March 2024
 ---
 
 Our baker needs a user account consisting of a pair of keys and an address.
+In this section, you use the Octez client to create an account and register it as a delegate.
 
 1. Open a new terminal window in the same environment.
 If you are using a Docker container, you can enter the container with the `docker exec` command, as in `docker exec -it my-image /bin/sh`.
 To get the name of the Docker container, you run the `docker ps` command.
 
-1. Set your installation of the Octez client to use your node:
-
-   - If you have not used the Octez client yet, run this command to initialize it:
-
-      ```bash
-      octez-client -E http://127.0.0.1:8732 config init
-      ```
-
-   - If you have already initialized the Octez client, run this command to instruct it to query your node:
-
-      ```bash
-      octez-client -E http://127.0.0.1:8732 config update
-      ```
-
-   For bakers, it's important to set the Octez client to use their node rather than a public node because the baker daemon uses the client configuration and the baker daemon should use the local node.
-
-1. Optional: Hide the network warning message by running this command:
+1. Optional: Hide the Octez client's network warning message by running this command:
 
    ```bash
    export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=y
@@ -61,6 +46,16 @@ This command creates an account and associates it with the `my_baker` alias:
    octez-client get balance for my_baker
    ```
 
+   If you get an error on this command, your local node isn't ready yet.
+   Until the node has finished bootstrapping, pass the public RPC endpoint for Weeklynet in the `--endpoint` argument, as in this example:
+
+   ```bash
+   octez-client --endpoint https://rpc.weeklynet-2024-01-17.teztnets.com get balance for my_baker
+   ```
+
+   Don't set the client endpoint to the public node permanently because it should use your local node whenever possible.
+   For bakers, it's important to set the Octez client to use their node rather than a public node because the baker daemon uses the client configuration and the baker daemon should use the local node.
+
 1. Get some tez from the Weeklynet faucet.
 
    In order to get some consensus and DAL rights, we need to put some tez in the account. Fortunately, getting free testnet tez is easy thanks to the testnet faucet. To use it, we need to enter the generated address in the Weeklynet faucet linked from https://teztnets.com/weeklynet-about. We need at least 6k tez for running a baker but the more tez we have the more rights we will get and the shorter we will have to wait to produce blocks and attestations. That being said, baking with too much stake prevents us from leaving the network without disturbing or even halting it so to avoid breaking the network for all other testers let's not be too greedy. 50k tez is enough to get enough rights to easily check if our baker behaves as expected while not disturbing the network too much when our baker stops operating.
@@ -78,6 +73,8 @@ This command creates an account and associates it with the `my_baker` alias:
    ```bash
    octez-client register key my_baker as delegate
    ```
+
+   Again, pass the `--endpoint` argument if your node has not finished bootstrapping.
 
 1. Stake the tez, saving a small amount for transaction fees.
 For example, if your account has 50k tez, stake 49990 tez by running this command:

--- a/docs/tutorials/join-dal-baker/prepare-account.md
+++ b/docs/tutorials/join-dal-baker/prepare-account.md
@@ -11,7 +11,7 @@ Our baker needs a user account consisting of a pair of keys and an address.
 If you are using a Docker container, you can enter the container with the `docker exec` command, as in `docker exec -it my-image /bin/sh`.
 To get the name of the Docker container, you run the `docker ps` command.
 
-1. Set your installation of the Octez client to use your node instead of the public Weeklynet node:
+1. Set your installation of the Octez client to use your node:
 
    - If you have not used the Octez client yet, run this command to initialize it:
 
@@ -25,7 +25,7 @@ To get the name of the Docker container, you run the `docker ps` command.
    octez-client -E http://127.0.0.1:8732 config update
    ```
 
-   Now that you have your own node, you can use its private RPC endpoint so your commands run quickly, instead of using the public RPC endpoint.
+   For bakers, it's important to set the Octez client to use their node rather than a public node because the baker daemon uses the client configuration and the baker daemon should use the local node.
 
 1. Optional: Hide the network warning message by running this command:
 

--- a/docs/tutorials/join-dal-baker/prepare-account.md
+++ b/docs/tutorials/join-dal-baker/prepare-account.md
@@ -19,7 +19,7 @@ To get the name of the Docker container, you run the `docker ps` command.
    octez-client -E http://127.0.0.1:8732 config init
    ```
 
-   If you have already initialized the Octez client, run this command to switch to your node:
+   If you have already initialized the Octez client, run this command to instruct it to query your node:
 
    ```bash
    octez-client -E http://127.0.0.1:8732 config update

--- a/docs/tutorials/join-dal-baker/prepare-account.md
+++ b/docs/tutorials/join-dal-baker/prepare-account.md
@@ -15,15 +15,15 @@ To get the name of the Docker container, you run the `docker ps` command.
 
    - If you have not used the Octez client yet, run this command to initialize it:
 
-   ```bash
-   octez-client -E http://127.0.0.1:8732 config init
-   ```
+      ```bash
+      octez-client -E http://127.0.0.1:8732 config init
+      ```
 
-   If you have already initialized the Octez client, run this command to instruct it to query your node:
+   - If you have already initialized the Octez client, run this command to instruct it to query your node:
 
-   ```bash
-   octez-client -E http://127.0.0.1:8732 config update
-   ```
+      ```bash
+      octez-client -E http://127.0.0.1:8732 config update
+      ```
 
    For bakers, it's important to set the Octez client to use their node rather than a public node because the baker daemon uses the client configuration and the baker daemon should use the local node.
 

--- a/docs/tutorials/join-dal-baker/prepare-account.md
+++ b/docs/tutorials/join-dal-baker/prepare-account.md
@@ -2,7 +2,7 @@
 title: "Step 3: Set up a baker account on Weeklynet"
 authors: Tezos core developers
 last_update:
-  date: 19 February 2024
+  date: 28 February 2024
 ---
 
 Our baker needs a user account consisting of a pair of keys and an address.
@@ -13,11 +13,27 @@ To get the name of the Docker container, you run the `docker ps` command.
 
 1. Set your installation of the Octez client to use your node instead of the public Weeklynet node:
 
+   - If you have not used the Octez client yet, run this command to initialize it:
+
+   ```bash
+   octez-client -E http://127.0.0.1:8732 config init
+   ```
+
+   If you have already initialized the Octez client, run this command to switch to your node:
+
    ```bash
    octez-client -E http://127.0.0.1:8732 config update
    ```
 
    Now that you have your own node, you can use its private RPC endpoint so your commands run quickly, instead of using the public RPC endpoint.
+
+1. Optional: Hide the network warning message by running this command:
+
+   ```bash
+   export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=y
+   ```
+
+   This command suppresses the message that your instance of the Octez client is not using Mainnet.
 
 1. Create or import an account in the Octez client.
 The simplest way to get an account that works with Weeklynet is to use the Octez client to randomly generate an account.


### PR DESCRIPTION
In the DAL baker tutorial, we initialize the client in step 1 but do not use it. Then in step 3 we set its configuration. It's simpler to do this config once, so this PR removes that client initialization in step 1.