### PR TITLE
Rename "Tezos SDK for Unity" to "Tezos Unity SDK"

### DIFF
--- a/docs/dApps.md
+++ b/docs/dApps.md
@@ -23,7 +23,7 @@ It relies on wallets and tools to interact with the smart contracts on behalf of
 Some of these tools that allow an off-chain component to interact with smart contracts include:
 
 - [Taquito](./dApps/taquito), an SDK for JavaScript/TypeScript applications
-- The [Tezos SDK for Unity](./unity), a toolkit for the [Unity](https://unity.com/) game development platform
+- The [Tezos Unity SDK](./unity), a toolkit for the [Unity](https://unity.com/) game development platform
 - [Taqueria](https://taqueria.io/), a development platform for dApps
 
 The next pages in this section illustrate dApps with [examples](./dApps/samples), detail the main steps when developing dApps such as [Connecting to wallets](./dApps/wallets) and [Sending transactions](./dApps/sending-transactions), and introduce some [best practices](./dApps/best-practices)

--- a/docs/overview/common-applications.md
+++ b/docs/overview/common-applications.md
@@ -29,4 +29,4 @@ The California DMV is also using Tezos for its project to [put car titles on the
 
 ## Tezos in Gaming
 
-Recently, the [Tezos SDK for Unity](https://tezos.com/unity/) promises to make blockchain game development easier and faster. It allows for the addition of web3 features such as allowing players to link their accounts across games, mint, and trade in-game items and currencies, and show off their ranks and accomplishments on public, on-chain leaderboards.
+Recently, the [Tezos Unity SDK](https://tezos.com/unity/) promises to make blockchain game development easier and faster. It allows for the addition of web3 features such as allowing players to link their accounts across games, mint, and trade in-game items and currencies, and show off their ranks and accomplishments on public, on-chain leaderboards.

--- a/docs/unity.md
+++ b/docs/unity.md
@@ -1,11 +1,11 @@
 ---
-title: Tezos SDK for Unity
+title: Tezos Unity SDK
 authors: Tim McMackin
 last_update:
   date: 11 January 2024
 ---
 
-The Tezos SDK for Unity provides tools that let you access user wallets and Tezos in games and other Unity projects.
+The Tezos Unity SDK provides tools that let you access user wallets and Tezos in games and other Unity projects.
 You can use Tezos via the SDK to:
 
 - Use a player's Tezos account as their account for a game and their wallet as their way of logging in to the game

--- a/docs/unity/connecting-accounts.md
+++ b/docs/unity/connecting-accounts.md
@@ -36,7 +36,7 @@ QR code | Users scan a QR code with a wallet app | Yes | No | Yes
 Deep link | The application opens the user's wallet app directly | Yes | Yes | No
 Social wallets | The application opens the user's Kukai web-based wallet | Yes | No | No
 
-Regardless of the connection method, the Tezos SDK for Unity runs the `WalletConnected` or `WalletConnectionFailed` event, as appropriate.
+Regardless of the connection method, the Tezos Unity SDK runs the `WalletConnected` or `WalletConnectionFailed` event, as appropriate.
 For more information about events, see the [Unity SDK EventManager object](./reference/EventManager).
 
 <!-- TODO info about handshakes? -->

--- a/docs/unity/prefabs.md
+++ b/docs/unity/prefabs.md
@@ -6,7 +6,7 @@ last_update:
   date: 11 January 2024
 ---
 
-The Tezos SDK for Unity provides these prefabs:
+The Tezos Unity SDK provides these prefabs:
 
 ## TezosManager
 

--- a/docs/unity/quickstart.md
+++ b/docs/unity/quickstart.md
@@ -5,7 +5,7 @@ last_update:
   date: 11 January 2024
 ---
 
-Follow these steps to install the Tezos SDK for Unity in an existing Unity project and start using it.
+Follow these steps to install the Tezos Unity SDK in an existing Unity project and start using it.
 
 These instructions cover:
 

--- a/docs/unity/reference.md
+++ b/docs/unity/reference.md
@@ -6,7 +6,7 @@ last_update:
   date: 11 January 2024
 ---
 
-The Tezos SDK for Unity provides several objects that your Unity project can use to work with Tezos.
+The Tezos Unity SDK provides several objects that your Unity project can use to work with Tezos.
 These pages provide reference for the most important of these objects:
 
 - [API object](./reference/API): Provides information about the Tezos blockchain, such as what tokens accounts or contracts control


### PR DESCRIPTION
Renamed the name of the SDK as "Tezos Unity SDK" for the planned rebranding.