### PR TITLE
Details about packing and unpacking

### DIFF
--- a/docs/smart-contracts/serialization.md
+++ b/docs/smart-contracts/serialization.md
@@ -31,7 +31,6 @@ You can do so by packing it first and then applying a hash function such as `BLA
 
 ## Implementation details
 
-- Michelson: [Operations on bytes](https://tezos.gitlab.io/active/michelson.html#operations-on-bytes)
 - LIGO: [Pack and Unpack](https://ligolang.org/docs/language-basics/tezos-specific#pack-and-unpack)
 - SmartPy: [Packing and Unpacking](https://smartpy.io/manual/syntax/strings-and-bytes#packing-and-unpacking)
 - Archetype: [pack](https://archetype-lang.org/docs/reference/expressions/builtins#pack%28o%20:%20T%29), [unpack](https://archetype-lang.org/docs/reference/expressions/builtins#unpack%3CT%3E%28b%20:%20bytes%29)

--- a/docs/smart-contracts/serialization.md
+++ b/docs/smart-contracts/serialization.md
@@ -57,6 +57,12 @@ BYTES=$(octez-client unpack michelson data "0x050a00000016000032041dca76bac940b4
 octez-client normalize data "$BYTES" of type "address"
 ```
 
+For more information about the format that Tezos uses to pack and unpack data, install the `octez-codec` program and run this command:
+
+```bash
+octez-codec describe alpha.script.expr binary schema
+```
+
 ## Implementation details
 
 - LIGO: [Pack and Unpack](https://ligolang.org/docs/language-basics/tezos-specific#pack-and-unpack)


### PR DESCRIPTION
Info about packing and unpacking and some gotchas about the formatting.

Preview: https://docs-staging-git-packing-details-trili-tech.vercel.app/smart-contracts/serialization#formatting

- Should the Octez docs mention this formatting and provide more detail, such as the possible values for prefixes?
- Is this info about the octez-codec useful here? I added just the command to print out all the formatting info. https://tezos.stackexchange.com/a/4000/10849

Source: https://tezos.stackexchange.com/questions/5879/conversion-of-address-to-bytes/5895#5895