### PR TITLE
Update a RPC path in DAL rollup tutorial

### DIFF
--- a/docs/tutorials/build-files-archive-with-dal/publishing-on-the-dal.md
+++ b/docs/tutorials/build-files-archive-with-dal/publishing-on-the-dal.md
@@ -48,7 +48,7 @@ The DAL node provides an RPC endpoint for clients to send data to be added to a 
 1. Run this command to publish a message to the DAL:
 
    ```bash
-   curl localhost:10732/slot --data '"Hello, world!"' -H 'Content-Type: application/json'
+   curl localhost:10732/slots --data '"Hello, world!"' -H 'Content-Type: application/json'
    ```
 
    This command assumes that you have not changed the default RPC server address.


### PR DESCRIPTION
The path of the RPC used to publish a slot on the DAL has changed (`/slot` has become `/slots`). This PR updates the tutorial accordingly.