### PR TITLE
Fix card `Development environments` in the landing page

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -28,7 +28,7 @@ const FeatureList = [
   {
     emoji: '🧑‍💻️',
     title: 'Development environments',
-    href: 'developing/dev-environments',
+    href: 'developing',
     description: (
       <>
         Set up a development environment for your language of choice and its related tools. Use a local environment with a sandbox or a web-based IDE for development work.


### PR DESCRIPTION
Fix the link to a page that was moved in #361.

What can be more frustrating for a new developer than clicking into `start developing` just to see nothing but `page not found`? :)