### PR TITLE
DAL is now available on weeklynet

### DIFF
--- a/docs/architecture/data-availability-layer.md
+++ b/docs/architecture/data-availability-layer.md
@@ -2,13 +2,8 @@
 title: The Data Availability Layer
 authors: "Tim McMackin"
 last_update:
-  date: 7 February 2024
+  date: 10 June 2024
 ---
-
-:::note Experimental
-The Data Availability Layer is an experimental feature that is not yet available on Tezos Mainnet.
-The way the DAL works may change significantly before it is generally available.
-:::
 
 The Data Availability Layer (DAL) is a companion peer-to-peer network for the Tezos blockchain, designed to provide additional data bandwidth to Smart Rollups.
 It allows users to share large amounts of data in a way that is decentralized and permissionless, because anyone can join the network and post and read data on it.

--- a/docs/tutorials/build-files-archive-with-dal.md
+++ b/docs/tutorials/build-files-archive-with-dal.md
@@ -2,13 +2,8 @@
 title: Implement a file archive with the DAL and a Smart Rollup
 authors: 'Tezos Core Developers'
 last_update:
-  date: 9 February 2024
+  date: 10 June 2024
 ---
-
-:::note Experimental
-The Data Availability Layer is an experimental feature that is not yet available on Tezos Mainnet.
-The way the DAL works may change significantly before it is generally available.
-:::
 
 The Data Availability Layer (DAL) is a companion peer-to-peer network for the Tezos blockchain, designed to provide additional data bandwidth to Smart Rollups.
 It allows users to share large amounts of data in a way that is decentralized and permissionless, because anyone can join the network and post and read data on it.
@@ -21,7 +16,7 @@ You will learn:
 - How to host a DAL node
 - How to publish data and files with the DAL
 
-Because the DAL is not yet available on Tezos Mainnet, this tutorial uses the [Weeklynet test network](https://teztnets.com/weeklynet-about), which runs on a newer version of the protocol that includes the DAL.
+This tutorial uses the [Weeklynet test network](https://teztnets.com/weeklynet-about).
 Weeklynet runs just like other Tezos networks like Mainnet and Ghostnet, with its own nodes, bakers, and accusers, so you don't need to run your own nodes and bakers.
 
 See these links for more information about the DAL:

--- a/docs/tutorials/join-dal-baker.md
+++ b/docs/tutorials/join-dal-baker.md
@@ -2,16 +2,11 @@
 title: Join the DAL as a baker, in 5 steps
 authors: Tezos core developers
 last_update:
-  date: 7 February 2024
+  date: 10 June 2024
 ---
 
 The Tezos data availability layer (DAL) is a key component for the scalability of Tezos.
 In a nutshell, the DAL increases the data bandwidth available for Tezos Smart Rollups by providing a peer-to-peer network that they can use to fetch data without compromising security.
-
-:::note Experimental
-The data availability layer is an experimental feature that is not yet available on Tezos Mainnet.
-The way the DAL works may change significantly before it is generally available.
-:::
 
 Just like layer 1, Tezos bakers ensure the security of the DAL.
 Bakers not only produce blocks but also attest that other bakers' blocks are valid and properly published on layer 1.


### PR DESCRIPTION
Update docs to remove info about DAL not being available on Mainnet.

I'll look into updating the tutorials to use Ghostnet instead of Weeklynet, but it may depend on how long it takes to get baking rights on Ghostnet.