### PR TITLE
Fix hash for glossary headings

### DIFF
--- a/src/scripts/process_downloaded_glossary.js
+++ b/src/scripts/process_downloaded_glossary.js
@@ -72,8 +72,8 @@ const process_glossary = async () => {
   sectionHeaderLinks.forEach((link) => {
     link.setAttribute('class', 'hash-link');
     const title = link.parentNode.firstChild.textContent;
-    link.setAttribute('aria-label', 'Direct link to' + title);
-    link.setAttribute('title', 'Direct link to' + title);
+    link.setAttribute('aria-label', 'Direct link to ' + title);
+    link.setAttribute('title', 'Direct link to ' + title);
     link.textContent = '';
   });
 

--- a/src/scripts/process_downloaded_glossary.js
+++ b/src/scripts/process_downloaded_glossary.js
@@ -67,6 +67,16 @@ const process_glossary = async () => {
     }
   });
 
+  // Convert section header links to match the rest of the site
+  const sectionHeaderLinks = trimmed.querySelectorAll('a.headerlink');
+  sectionHeaderLinks.forEach((link) => {
+    link.setAttribute('class', 'hash-link');
+    const title = link.parentNode.firstChild.textContent;
+    link.setAttribute('aria-label', 'Direct link to' + title);
+    link.setAttribute('title', 'Direct link to' + title);
+    link.textContent = '';
+  });
+
   // Wrap with <div class='imported-glossary'></div> to apply custom styles
   const wrapper = new JSDOM('<div id="imported-glossary"></div>');
   const imported_glossary = wrapper.window.document.querySelector('div#imported-glossary');


### PR DESCRIPTION
The headings for the imported glossary show the hash mark all the time, but the rest of the site shows them only on hover. 

In this screencap, the hash is shown even when the mouse is not over the heading:
![Screenshot 2024-08-01 at 10 00 08 AM](https://github.com/user-attachments/assets/debe9493-efcc-4e43-b225-a580abc5af4d)

This PR changes the header links in the imported glossary from this:

```
<a class="headerlink" href="#tezos" title="Link to this heading">#</a>
```

To this, which matches other links on the site:

```
<a class="hash-link" href="#tezos" title="Direct link to Tezos" aria-label="Direct link to Tezos"></a>
```