### PR TITLE
Update Smart Rollup tutorial

### DIFF
--- a/docs/tutorials/smart-rollup/deploy.md
+++ b/docs/tutorials/smart-rollup/deploy.md
@@ -1,7 +1,7 @@
 ---
 title: "Part 4: Deploying (originating) the rollup"
 last_update:
-  date: 25 October 2023
+  date: 1 August 2024
 ---
 
 Smart Rollups are originated in a way similar to smart contracts.
@@ -31,6 +31,12 @@ This command creates an address for the rollup and stores a small amount of data
    ```
 
    Now the second terminal window is running inside the container just like the first one.
+
+1. In the new terminal window, go to the folder with the Smart Rollup code:
+
+   ```bash
+   cd hello-world-kernel
+   ```
 
 1. In the second terminal window, run this command to verify that the sandbox is running with the correct protocol:
 

--- a/docs/tutorials/smart-rollup/optimize.md
+++ b/docs/tutorials/smart-rollup/optimize.md
@@ -1,7 +1,7 @@
 ---
 title: "Part 3: Optimizing the kernel"
 last_update:
-  date: 25 October 2023
+  date: 7 August 2024
 ---
 
 To originate the kernel on Tezos, it must fit within the maximum size for a layer 1 operation (32KB).
@@ -92,7 +92,8 @@ In these steps, you reduce the size of the kernel:
 
    Then you can use the `step inbox` command to simulate receiving the inbox from layer 1.
    You can see the hello world kernel messages in the log, which shows that the upgrade from the installer kernel to the full kernel was successful.
-   Press Ctrl + C to end the debugging session.
+
+1. Press Ctrl + C to end the debugging session.
 
 1. Create a hexadecimal version of the installer kernel by running this command outside of the Docker container:
 

--- a/docs/tutorials/smart-rollup/run.md
+++ b/docs/tutorials/smart-rollup/run.md
@@ -1,7 +1,7 @@
 ---
 title: "Part 5: Running and interacting with the rollup node"
 last_update:
-  date: 25 October 2023
+  date: 1 August 2024
 ---
 
 Now that the Smart Rollup is originated on layer 1, anyone can run a Smart Rollup node for it.
@@ -21,7 +21,7 @@ In these steps, you start a Smart Rollup node, but note that anyone can run a no
 1. In the second terminal window, in the Docker container, start the rollup node:
 
    ```bash
-   octez-smart-rollup-node-alpha run operator for "test_smart_rollup" \
+   octez-smart-rollup-node run operator for "test_smart_rollup" \
        with operators "bootstrap2" --data-dir ~/.tezos-rollup-node/ \
        --log-kernel-debug --log-kernel-debug-file hello_kernel.debug
    ```

--- a/docs/tutorials/smart-rollup/set-up.md
+++ b/docs/tutorials/smart-rollup/set-up.md
@@ -65,7 +65,7 @@ Later, you will use this image to run a sandbox Tezos environment for testing th
 1. Run this command to start the Docker image, open a command-line terminal in that image, and mount the `hello-world-kernel` folder in it:
 
    ```bash
-   docker run -it --rm --volume .:/home/tezos/hello-world-kernel --entrypoint /bin/sh --name octez-container tezos/tezos:master
+   docker run -it --rm --volume $(pwd):/home/tezos/hello-world-kernel --entrypoint /bin/sh --name octez-container tezos/tezos:master
    ```
 
    Your command-line prompt changes to indicate that it is now inside the running Docker container.

--- a/docs/tutorials/smart-rollup/set-up.md
+++ b/docs/tutorials/smart-rollup/set-up.md
@@ -65,7 +65,7 @@ Later, you will use this image to run a sandbox Tezos environment for testing th
 1. Run this command to start the Docker image, open a command-line terminal in that image, and mount the `hello-world-kernel` folder in it:
 
    ```bash
-   docker run -it --rm --volume $(pwd):/home/tezos/hello-world-kernel --entrypoint /bin/sh --name octez-container tezos/tezos:master
+   docker run -it --rm --volume .:/home/tezos/hello-world-kernel --entrypoint /bin/sh --name octez-container tezos/tezos:master
    ```
 
    Your command-line prompt changes to indicate that it is now inside the running Docker container.

--- a/docs/tutorials/smart-rollup/set-up.md
+++ b/docs/tutorials/smart-rollup/set-up.md
@@ -1,7 +1,7 @@
 ---
 title: "Part 1: Setting up the application"
 last_update:
-  date: 25 October 2023
+  date: 12 August 2024
 ---
 
 To set up the application for the tutorial, you must configure Rust to build the kernel and start a Docker container that has resources that are needed to debug and deploy it.
@@ -77,7 +77,7 @@ Later, you will use this image to run a sandbox Tezos environment for testing th
    ```bash
    octez-node --version
    octez-smart-rollup-wasm-debugger --version
-   octez-smart-rollup-node-alpha --version
+   octez-smart-rollup-node --version
    octez-client --version
    ```
 


### PR DESCRIPTION
Tutorial needs some updates, primarily that for the binary you can use `octez-smart-rollup-node` without the `alpha`.

Related issue: if you wait too long between origination and starting the Smart Rollup node, it can't get enough info from the rolling L1 node. This fix changes the sandbox for this tutorial to use an archive node: https://gitlab.com/trili/hello-world-kernel/-/merge_requests/4