### PR TITLE
Update app for Svelte 5

### DIFF
--- a/docs/tutorials/build-your-first-app/setting-up-app.md
+++ b/docs/tutorials/build-your-first-app/setting-up-app.md
@@ -2,7 +2,7 @@
 title: "Part 1: Setting up the application"
 authors: 'Claude Barde, Tim McMackin'
 last_update:
-  date: 15 November 2023
+  date: 14 November 2024
 ---
 
 You can access Tezos through any JavaScript framework.
@@ -107,12 +107,11 @@ This tutorial uses the Svelte framework, and the following steps show you how to
 1. Replace the `src/main.js` file with this code:
 
    ```javascript
+   import { mount } from 'svelte';
    import './app.css'
-   import App from './App.svelte'
+   import App from './App.svelte';
 
-   const app = new App({
-     target: document.body,
-   })
+   const app = mount(App, { target: document.body });
 
    export default app
    ```


### PR DESCRIPTION
This tutorial needs a small update for Svelte 5:
https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes

Updates to the application itself in: https://github.com/trilitech/tutorial-applications/pull/13