### PR TITLE
Update smart rollup tutorial

### DIFF
--- a/docs/tutorials/smart-rollup/set-up.md
+++ b/docs/tutorials/smart-rollup/set-up.md
@@ -1,7 +1,7 @@
 ---
 title: "Part 1: Setting up the application"
 last_update:
-  date: 12 August 2024
+  date: 14 November 2024
 ---
 
 To set up the application for the tutorial, you must configure Rust to build the kernel and start a Docker container that has resources that are needed to debug and deploy it.
@@ -21,7 +21,7 @@ Follow these steps to get the application code and build it:
 
    1. Verify that you have Rust version 1.73.0 or later installed by running `rustc --version`.
 
-   1. If you have an earlier version of Rust, use the `rustup` command to use version 1.73.0:
+   1. If you have a version of Rust later than 1.73.0, use the `rustup override` command to use version 1.73.0:
 
       ```bash
       rustup override set 1.73.0

--- a/docs/tutorials/smart-rollup/set-up.md
+++ b/docs/tutorials/smart-rollup/set-up.md
@@ -39,7 +39,7 @@ Follow these steps to get the application code and build it:
    cargo build --target wasm32-unknown-unknown
    ```
 
-   If the application builds correctly, the terminal shows a message that looks like "Finished dev [unoptimized + debuginfo] target(s) in 0.44s."
+   If the application builds correctly, the terminal shows a message that looks like "Finished dev [unoptimized + debuginfo] target(s) in 15s."
    You can see the compiled application in the `target/wasm32-unknown-unknown/debug` folder.
    In particular, the compiled kernel is in the `hello_world_kernel.wasm` file.
 


### PR DESCRIPTION
- The override command is for versions of Rust **after** 1.73, not before.
- Clarify how long a command usually takes