### PR TITLE
Script to concatenate MD files

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run concat
-      - run: mv allMdFilesConcatenated.md ./build/
+      - run: mv allPageSourceFiles.md ./build/
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PRODUCTION_KEY_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 18
       - run: npm ci
       - run: npm run build
+      - run: npm run concat
+      - run: mv allMdFilesConcatenated.md ./build/
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PRODUCTION_KEY_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run concat
-      - run: mv allPageSourceFiles.md ./build/
+      - run: mv allPageSourceFiles.txt ./build/
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PRODUCTION_KEY_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run concat
-      - run: mv allPageSourceFiles.txt ./build/
+      - run: mv allPageSourceFiles.txt allTutorials.txt ./build/
       - uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_S3_PRODUCTION_KEY_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ node_modules
 out
 build
 _glossaryBuild
-allPageSourceFiles.md
+allPageSourceFiles.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ node_modules
 out
 build
 _glossaryBuild
-allMdFilesConcatenated.md
+allPageSourceFiles.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ out
 build
 _glossaryBuild
 allPageSourceFiles.txt
-
+allTutorials.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 out
 build
 _glossaryBuild
+allMdFilesConcatenated.md
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,10 @@
         "minimist": "1.2.8",
         "mocha": "10.2.0",
         "rehype-stringify": "10.0.0",
+        "remark": "^15.0.1",
         "remark-parse": "11.0.0",
         "remark-rehype": "11.0.0",
+        "strip-markdown": "^6.0.0",
         "unified": "11.0.4",
         "unist-util-visit": "5.0.0"
       },
@@ -14716,6 +14718,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-directive": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.0.tgz",
@@ -15903,6 +15921,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-markdown": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-6.0.0.tgz",
+      "integrity": "sha512-mSa8FtUoX3ExJYDkjPUTC14xaBAn4Ik5GPQD45G5E2egAmeV3kHgVSTfIoSDggbF6Pk9stahVgqsLCNExv6jHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/style-to-object": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "node ./src/scripts/process_downloaded_glossary.js && docusaurus build",
+    "concat": "node ./src/scripts/concatenate.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "node ./src/scripts/process_downloaded_glossary.js && docusaurus build",
-    "concat": "node ./src/scripts/concatenate.js",
+    "concat": "node ./src/scripts/concatenate.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "minimist": "1.2.8",
     "mocha": "10.2.0",
     "rehype-stringify": "10.0.0",
+    "remark": "^15.0.1",
     "remark-parse": "11.0.0",
     "remark-rehype": "11.0.0",
+    "strip-markdown": "^6.0.0",
     "unified": "11.0.4",
     "unist-util-visit": "5.0.0"
   },

--- a/src/scripts/concatenate.js
+++ b/src/scripts/concatenate.js
@@ -3,11 +3,14 @@ const fs = require('fs');
 
 const sidebars = require('../../sidebars');
 const sidebarsToInclude = ['documentationSidebar'];
+const pathsToFilterOut = [
+  'overview/glossary',
+];
 
 // Given a docusaurus sidebar object, return a list of the local doc IDs in it
 function getIdsRecursive(sidebarObject) {
   if (typeof sidebarObject === 'string') {
-    return sidebarObject;
+    return pathsToFilterOut.includes(sidebarObject) ? null : sidebarObject;
   }
   if (sidebarObject.constructor.name == "Array") {
     return sidebarObject.reduce((list, oneSidebarObj) =>

--- a/src/scripts/concatenate.js
+++ b/src/scripts/concatenate.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 
 const sidebars = require('../../sidebars');
+const sidebarsToInclude = ['documentationSidebar'];
 
 // Given a docusaurus sidebar object, return a list of the local doc IDs in it
 function getIdsRecursive(sidebarObject) {
@@ -86,7 +87,8 @@ async function concatEverything() {
   }
 
   // Get list of MD file IDs in order from sidebars.js
-  const allSidebarNames = Object.keys(sidebars);
+  const allSidebarNames = Object.keys(sidebars)
+    .filter((sidebarName) => sidebarsToInclude.includes(sidebarName));
   const allMdIds = allSidebarNames
     .reduce((list, sidebarName) =>
       list.concat(getIdsRecursive(sidebars[sidebarName])),

--- a/src/scripts/concatenate.js
+++ b/src/scripts/concatenate.js
@@ -52,29 +52,30 @@ async function getFilePath(fileId) {
 }
 
 // Remove the front matter from an MD file and replace with an H1
-// Got to remove FM because multiple FM blocks are not legal
+// Got to remove FM because multiple FM blocks break some markdown tools
 // Could do this with gray-matter but I don't want to add the dependency
 function removeFrontMatter(mdText) {
-  let outputLines = [];
   const lines = mdText.split('\n');
   let inFrontMatter = false;
   let doneWithFrontMatter = false;
   const h1Regex = /^title:\s+(.*)$/;
+  let titleLine = '';
+  let line = '';
 
-  lines.forEach(line => {
+  while (lines.length > 0) {
+    line = lines.shift();
     if (line == '---') {
       doneWithFrontMatter = inFrontMatter;
       inFrontMatter = true;
     }
     if (inFrontMatter && !doneWithFrontMatter && h1Regex.test(line)) {
       const result = h1Regex.exec(line);
-      outputLines.push('# ' + result[1]);
+      titleLine = '# ' + result[1];
     }
     if (line != '---' && doneWithFrontMatter) {
-      outputLines.push(line);
+      return [titleLine, ''].concat(lines).join('\n');
     }
-  });
-  return outputLines.join('\n');
+  }
 }
 
 async function concatEverything() {

--- a/src/scripts/concatenate.js
+++ b/src/scripts/concatenate.js
@@ -1,0 +1,83 @@
+const path = require('path');
+const fs = require('fs');
+
+const sidebars = require('../../sidebars');
+
+// Given a docusaurus sidebar object, return a list of the local doc IDs in it
+function getIdsRecursive(sidebarObject) {
+  if (typeof sidebarObject === 'string') {
+    return sidebarObject;
+  }
+  if (sidebarObject.constructor.name == "Array") {
+    return sidebarObject.reduce((list, oneSidebarObj) =>
+      list.concat(getIdsRecursive(oneSidebarObj)),
+    []);
+  }
+  switch(sidebarObject.type) {
+    case 'category':
+      return [sidebarObject?.link?.id].concat(getIdsRecursive(sidebarObject.items));
+    case 'doc':
+      return sidebarObject.id;
+    case 'link':
+      if (sidebarObject.href && sidebarObject.href.startsWith('http')) {
+        return null;
+      } else {
+        return sidebarObject.href;
+      }
+    default:
+      return null;
+  }
+}
+
+// Given a doc file ID from the sidebar, get the filename path
+async function getFilePath(fileId) {
+  const mdPath = path.resolve(__dirname, '../../docs', fileId) + '.md';
+  try {
+    await fs.promises.access(mdPath, fs.constants.F_OK);
+    return mdPath;
+  } catch {
+    // Do nothing
+  }
+  const mdxPath = mdPath + 'x';
+  try {
+    await fs.promises.access(mdxPath, fs.constants.F_OK);
+    return mdxPath;
+  } catch {
+    console.error("Could not file file with sidebar ID", fileId);
+  }
+}
+
+async function concatEverything() {
+
+  const outputPath = path.resolve(__dirname, '../../', 'allMdFilesConcatenated.md');
+
+  // Remove old concatenated file if it exists
+  try {
+    await fs.promises.access(outputPath, fs.constants.F_OK);
+    await fs.promises.unlink(outputPath);
+  } catch {
+    // Do nothing because the file does not exist
+  }
+
+  // Get list of MD file IDs in order from sidebars.js
+  const allSidebarNames = Object.keys(sidebars);
+  const allMdIds = allSidebarNames
+    .reduce((list, sidebarName) =>
+      list.concat(getIdsRecursive(sidebars[sidebarName])),
+    [])
+    .filter((item) => item);
+
+  // Find the matching file paths
+  const allFilePaths = await Promise.all(allMdIds.map(getFilePath));
+
+  // Read and concat the files in TOC order
+  await allFilePaths.reduce(async (previousPromise, oneFilePath) => {
+    await previousPromise;
+    const oneFileText = await fs.promises.readFile(oneFilePath, 'utf8') + '\n\n';
+    return fs.promises.appendFile(outputPath, oneFileText);
+  }, Promise.resolve());
+
+  console.log('Wrote concatenated file to', outputPath);
+}
+
+concatEverything();

--- a/src/scripts/concatenate.js
+++ b/src/scripts/concatenate.js
@@ -79,7 +79,7 @@ function removeFrontMatter(mdText) {
 
 async function concatEverything() {
 
-  const outputPath = path.resolve(__dirname, '../../', 'allMdFilesConcatenated.md');
+  const outputPath = path.resolve(__dirname, '../../', 'allPageSourceFiles.md');
 
   // Remove old concatenated file if it exists
   try {

--- a/src/scripts/concatenate.mjs
+++ b/src/scripts/concatenate.mjs
@@ -1,7 +1,12 @@
-const path = require('path');
-const fs = require('fs');
+import path from 'path';
+import fs from 'fs';
 
-const sidebars = require('../../sidebars');
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+import sidebars from '../../sidebars.js';
 const sidebarsToInclude = ['documentationSidebar'];
 const pathsToFilterOut = [
   'overview/glossary',

--- a/src/scripts/concatenate.mjs
+++ b/src/scripts/concatenate.mjs
@@ -88,7 +88,7 @@ function removeFrontMatter(mdText) {
 
 async function concatEverything() {
 
-  const outputPath = path.resolve(__dirname, '../../', 'allPageSourceFiles.md');
+  const outputPath = path.resolve(__dirname, '../../', 'allPageSourceFiles.txt');
 
   // Remove old concatenated file if it exists
   try {

--- a/src/scripts/concatenate.mjs
+++ b/src/scripts/concatenate.mjs
@@ -117,7 +117,9 @@ async function concatEverything() {
     const oneFileText = await remark()
       .use(strip)
       .process(markdownText);
-    return fs.promises.appendFile(outputPath, String(oneFileText) + '\n\n');
+    // Fix strip plugin escaping `_` as `\_`
+    const oneFileTextFixEscaped = String(oneFileText).replaceAll('\_', '_');
+    return fs.promises.appendFile(outputPath, oneFileTextFixEscaped + '\n\n');
   }, Promise.resolve());
 
   console.log('Wrote concatenated file to', outputPath);


### PR DESCRIPTION
This script concatenates all MD files and strips the markdown code into a single text file so you can feed it to an LLM. Run it by running `npm run concat`. It outputs to `allPageSourceFiles.txt` and if I've done it correctly, that file will be at https://docs.tezos.com/allPageSourceFiles.txt.