### PR TITLE
Clarify variables

### DIFF
--- a/docs/developing/octez-client/transactions.md
+++ b/docs/developing/octez-client/transactions.md
@@ -16,7 +16,7 @@ To send tez from a source account to a target account, use the `octez-client tra
 octez-client transfer 42 from account1 to account2 --fee-cap 0.9
 ```
 
-You can use addresses or local aliases for the source and target accounts, but Octez must have the private key for the source account in order to sign the transaction.
+You can use addresses or local aliases for the source and target accounts, but Octez must have the private key for the source account to sign the transaction.
 
 To check the balance of an account after a transaction, use the `octez-client get balance for` command and pass the alias or address of an account, as in this example:
 
@@ -37,7 +37,7 @@ octez-client --wait none transfer 0 \
 ```
 
 This command calls the `increment` entrypoint of the `my-counter` contract and includes 0 tez and up to 0.1 tez in fees with the transaction.
-It passes the parameter "5" to the endpoint.
+It passes the parameter "5" to the entrypoint.
 You can use a local alias or the full address for the smart contract.
 
 Because entrypoints accept parameters in Michelson code, you must encode the values that you send as Michelson values.

--- a/docs/developing/octez-client/transactions.md
+++ b/docs/developing/octez-client/transactions.md
@@ -26,11 +26,13 @@ octez-client get balance for account1
 
 ## Calling smart contracts
 
-To call a smart contract, use the `octez-client transfer` command, as in this example from the [Deploy a smart contract](/tutorials/smart-contract) tutorial:
+To call a smart contract, use the `octez-client transfer` command.
+Contracts can have aliases in the Octez client like accounts.
+This example calls a contract with the alias `my-counter`:
 
 ```bash
 octez-client --wait none transfer 0 \
-  from $MY_TZ_ADDRESS to my-counter \
+  from account1 to my-counter \
   --entrypoint 'increment' --arg '5' --burn-cap 0.1
 ```
 
@@ -61,7 +63,7 @@ To deploy (originate) a smart contract to the current network, use the `octez-cl
 
 ```bash
 octez-client originate contract my-counter \
-  transferring 0 from $MY_TZ_ADDRESS \
+  transferring 0 from account1 \
   running increment.tz \
   --init 10 --burn-cap 0.1 --force
 ```

--- a/docs/tutorials/join-dal-baker/run-dal-node.md
+++ b/docs/tutorials/join-dal-baker/run-dal-node.md
@@ -2,7 +2,7 @@
 title: "Step 3: Run an Octez DAL node"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 18 September 2024
+  date: 27 November 2024
 ---
 
 The DAL node is responsible for temporarily storing data and providing it to bakers and Smart Rollups.
@@ -11,12 +11,15 @@ The DAL node is responsible for temporarily storing data and providing it to bak
 You may need to adapt your firewall rules or set up network address translation (NAT) to direct external traffic to the DAL node.
 For more information, see [Running a DAL attester node](https://tezos.gitlab.io/shell/dal_run.html) in the Octez documentation.
 
-1. Initialize the DAL node by running its `config init` command, passing the address of your `octez-node` instance and your baker's address.
+1. Initialize the DAL node by running its `config init` command, passing the address of your `octez-node` instance in the `--endpoint` argument and your baker's account address in the `--attester-profiles` argument.
 For example, this command initializes the DAL node with the address of a local `octez-node` instance on port 8732 and stores data in the default DAL node directory (`~/.tezos-dal-node`):
 
    ```bash
-   octez-dal-node config init --endpoint http://127.0.0.1:8732 --attester-profiles="$MY_ADDRESS"
+   octez-dal-node config init --endpoint http://127.0.0.1:8732 \
+     --attester-profiles=tz1QCVQinE8iVj1H2fckqx6oiM85CNJSK9Sx
    ```
+
+   You cannot use the `my_baker` alias from the Octez client as in the previous section, so you must specify the address of your baker's account explicitly.
 
 1. Start the DAL node by running this command:
 


### PR DESCRIPTION
Clarify a few places where we use variables without explaining what they are. We can assume that $HOME and $PATH are defined, but if I use $MY_ACCOUNT that should have been explicitly defined.