### PR TITLE
Disambiguate NFT tutorials

### DIFF
--- a/docs/tutorials/create-an-nft/nft-taquito.md
+++ b/docs/tutorials/create-an-nft/nft-taquito.md
@@ -15,6 +15,15 @@ In this tutorial, you will learn:
 - How to deploy (originate) a smart contract to Tezos
 - How to use the [Taquito](https://tezostaquito.io/) JavaScript/TypeScript SDK to access Tezos and user wallets and to send transactions to Tezos
 
+:::note
+
+This tutorial covers both the backend and frontend parts of a dApp.
+For a simpler tutorial that covers creating only the frontend application, see [Mint NFTs from a web app](tutorials/create-an-nft/nft-web-app).
+
+You can also use command-line tools to create NFTs as described in the tutorial [Create NFTs from the command line](/tutorials/create-an-nft/nft-tznft).
+
+:::
+
 ## What is a non-fungible token (NFT)?
 
 An NFT is a special type of blockchain token that represents something unique.

--- a/docs/tutorials/create-an-nft/nft-taquito.md
+++ b/docs/tutorials/create-an-nft/nft-taquito.md
@@ -20,8 +20,6 @@ In this tutorial, you will learn:
 This tutorial covers both the backend and frontend parts of a dApp.
 For a simpler tutorial that covers creating only the frontend application, see [Mint NFTs from a web app](tutorials/create-an-nft/nft-web-app).
 
-You can also use command-line tools to create NFTs as described in the tutorial [Create NFTs from the command line](/tutorials/create-an-nft/nft-tznft).
-
 :::
 
 ## What is a non-fungible token (NFT)?

--- a/docs/tutorials/create-an-nft/nft-tznft.md
+++ b/docs/tutorials/create-an-nft/nft-tznft.md
@@ -17,14 +17,6 @@ In this tutorial, you will learn:
 - How to transfer NFTs and change operator permissions for them
 - How to mint NFTs to a testnet
 
-:::note
-
-This tutorial covers creating NFTs from the command line.
-To create a web application that creates NFTs based on an existing backend application, see the tutorial [Mint NFTs from a web app](tutorials/create-an-nft/nft-web-app).
-To create your own frontend and backend application to create NFTs, see the tutorial [Create a contract and web app that mints NFTs](/tutorials/create-an-nft/nft-taquito).
-
-:::
-
 ## What is a non-fungible token (NFT)?
 
 An NFT is a special type of blockchain token that represents something unique.

--- a/docs/tutorials/create-an-nft/nft-tznft.md
+++ b/docs/tutorials/create-an-nft/nft-tznft.md
@@ -17,6 +17,14 @@ In this tutorial, you will learn:
 - How to transfer NFTs and change operator permissions for them
 - How to mint NFTs to a testnet
 
+:::note
+
+This tutorial covers creating NFTs from the command line.
+To create a web application that creates NFTs based on an existing backend application, see the tutorial [Mint NFTs from a web app](tutorials/create-an-nft/nft-web-app).
+To create your own frontend and backend application to create NFTs, see the tutorial [Create a contract and web app that mints NFTs](/tutorials/create-an-nft/nft-taquito).
+
+:::
+
 ## What is a non-fungible token (NFT)?
 
 An NFT is a special type of blockchain token that represents something unique.

--- a/docs/tutorials/create-an-nft/nft-web-app.md
+++ b/docs/tutorials/create-an-nft/nft-web-app.md
@@ -21,8 +21,6 @@ For simplicity, it uses an existing backend application, a smart contract runnin
 To create your own NFTs in a production application, you must deploy your own smart contract and backend application.
 For a tutorial that covers creating both the frontend and backend application, see [Create a contract and web app that mints NFTs](/tutorials/create-an-nft/nft-taquito).
 
-You can also use command-line tools to create NFTs as described in the tutorial [Create NFTs from the command line](/tutorials/create-an-nft/nft-tznft).
-
 :::
 
 ## Prerequisites

--- a/docs/tutorials/create-an-nft/nft-web-app.md
+++ b/docs/tutorials/create-an-nft/nft-web-app.md
@@ -14,6 +14,17 @@ You will learn:
 - How to connect to a user's wallet
 - How to mint NFTs on behalf of a user
 
+:::note
+
+This tutorial covers creating a web application to interact with Tezos and mint NFTs.
+For simplicity, it uses an existing backend application, a smart contract running on Tezos.
+To create your own NFTs in a production application, you must deploy your own smart contract and backend application.
+For a tutorial that covers creating both the frontend and backend application, see [Create a contract and web app that mints NFTs](/tutorials/create-an-nft/nft-taquito).
+
+You can also use command-line tools to create NFTs as described in the tutorial [Create NFTs from the command line](/tutorials/create-an-nft/nft-tznft).
+
+:::
+
 ## Prerequisites
 
 This tutorial uses [JavaScript](https://www.javascript.com/), so it will be easier if you are familiar with JavaScript.


### PR DESCRIPTION
I created this as a potential solution to https://github.com/trilitech/tezos-developer-docs/issues/473.

Provides disambiguation for the 3 NFT-related tutorials. Not sure if it's better to do this or to reduce the number of tutorials. Very open to opinions. I did not mention the tznft tutorial because I'm considering removing it because tznft is no longer maintained and it's a very niche tool.

Fixes https://github.com/trilitech/tezos-developer-docs/issues/473.