### PR TITLE
Update codeowners for current team working on docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @trilitech/tur-docs
+* @trilitech/techrel-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @trilitech/tur-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @trilitech/developer-success


### PR DESCRIPTION
The Dev Success team no longer exists. Update the team that is asked to review PRs in this repo.

New team is https://github.com/orgs/trilitech/teams/tur-docs