### PR TITLE
Update SmartPy links

### DIFF
--- a/docs/architecture/governance/improvement-process.md
+++ b/docs/architecture/governance/improvement-process.md
@@ -26,7 +26,7 @@ For those familiar with [ERC20](https://eips.ethereum.org/EIPS/eip-20), the FA1.
 The FA1.2 specification is described in detail in [TZIP-7](https://gitlab.com/tzip/tzip/blob/master/proposals/tzip-7/tzip-7.md).
 For implementations, see these templates:
 
-- For SmartPy templates, see [Tokens](https://smartpy.io/guides/tokens/) in the SmartPy documentation.
+- For SmartPy templates, see the SmartPy [FA2 library](https://smartpy.io/manual/libraries/FA2-lib/overview) in the SmartPy documentation.
 - For LIGO templates, see the [`@ligo/fa`](https://packages.ligolang.org/package/@ligo/fa) package.
 - For Archetype templates, see [Templates](https://archetype-lang.org/docs/templates/overview/) in the Archetype documentation.
 

--- a/docs/architecture/tokens.md
+++ b/docs/architecture/tokens.md
@@ -119,7 +119,7 @@ These standards are named with the prefix FA, which stands for _financial applic
 
 You can use templates for smart contracts adhering to these standards, instead of writing your own contract from scratch:
 
-- For SmartPy templates, see [Tokens](https://smartpy.io/guides/tokens/) in the SmartPy documentation.
+- For SmartPy templates, see the SmartPy [FA2 library](https://smartpy.io/manual/libraries/FA2-lib/overview) in the SmartPy documentation.
 - For LIGO templates, see the [`@ligo/fa`](https://packages.ligolang.org/package/@ligo/fa) package.
 - For Archetype templates, see [Templates](https://archetype-lang.org/docs/templates/overview/) in the Archetype documentation.
 

--- a/docs/developing/testing.md
+++ b/docs/developing/testing.md
@@ -103,7 +103,7 @@ For more information about avoiding flaws in contracts, see [Avoiding flaws](htt
 
 - Michelson: [Mockup mode](https://tezos.gitlab.io/user/mockup.html)
 - Archetype: [Completium test scenario](https://completium.com/docs/contract/test-scenario)
-- SmartPy: [Tests and scenarios](https://smartpy.io/manual/scenarios/overview)
+- SmartPy: [Test scenarios](https://smartpy.io/manual/scenarios/test_scenarios)
 - LIGO: [Testing LIGO](https://ligolang.org/docs/next/testing/)
 
 ## Next steps

--- a/docs/smart-contracts/data-types/complex-data-types.md
+++ b/docs/smart-contracts/data-types/complex-data-types.md
@@ -25,7 +25,7 @@ For a complete list of data types that are available, see the reference informat
 - Michelson: [Types](https://tezos.gitlab.io/michelson-reference/#types)
 - LIGO: [Introduction](https://ligolang.org/docs/intro/introduction?lang=jsligo)
 - Archetype: [Types](https://archetype-lang.org/docs/reference/types)
-- SmartPy: [Overview](https://smartpy.io/manual/syntax/overview)
+- SmartPy: [Overview](https://smartpy.io/manual/introduction/overview)
 
 ## Pairs {#pairs}
 
@@ -65,7 +65,7 @@ $$O(\log_2 (size))$$, whereas for a right comb, it's $$O(size)$$.
 
 - Michelson: [Operations on pairs and right combs](https://tezos.gitlab.io/active/michelson.html#operations-on-pairs-and-right-combs)
 - LIGO: [Tuples](https://ligolang.org/docs/language-basics/sets-lists-tuples#tuples)
-- SmartPy: [Tuples and Records](https://smartpy.io/manual/syntax/tuples-and-records)
+- SmartPy: [Tuples](https://smartpy.io/manual/data-types/tuples)
 - Archetype: [Composite types](https://archetype-lang.org/docs/language-basics/composite#tuple), [Tuple](https://archetype-lang.org/docs/reference/types#tuple)
 
 ## Records {#records}
@@ -115,7 +115,7 @@ type person: record
 
 - Archetype: [Record](https://archetype-lang.org/docs/language-basics/composite#record)
 - LIGO: [Records](https://ligolang.org/docs/language-basics/maps-records#records)
-- SmartPy: [Tuples and Records](https://smartpy.io/manual/syntax/tuples-and-records)
+- SmartPy: [Records](https://smartpy.io/manual/data-types/records)
 
 ## Options {#options}
 
@@ -166,7 +166,7 @@ Alternatively (but harder to understand without comments), you can use the speci
 
 - Michelson: [Operations on optional values](https://tezos.gitlab.io/active/michelson.html#operations-on-optional-values)
 - LIGO: [Optional values](https://ligolang.org/docs/language-basics/unit-option-pattern-matching#optional-values)
-- SmartPy: [Options](https://smartpy.io/docs/types/options/)
+- SmartPy: [Options and variants](https://smartpy.io/manual/data-types/options-and-variants)
 - Archetype: [Options](https://archetype-lang.org/docs/reference/types#option%3CT%3E)
 
 ## Big-maps and maps {#big-maps}
@@ -285,7 +285,7 @@ Here is a table representing an example of a contract that uses two big-maps:
 - Michelson: [Operations on big-maps](https://tezos.gitlab.io/active/michelson.html#operations-on-big-maps)
 - Archetype: [Assets](https://archetype-lang.org/docs/reference/instructions/asset), [Map](https://archetype-lang.org/docs/language-basics/container#map)
 - LIGO: [Maps](https://ligolang.org/docs/language-basics/maps-records#maps), [Big-maps](https://ligolang.org/docs/language-basics/maps-records#big-maps)
-- SmartPy: [Maps and big-maps](https://smartpy.io/manual/syntax/lists-sets-and-maps#maps)
+- SmartPy: [Lists, sets, and maps](https://smartpy.io/manual/data-types/lists-sets-and-maps)
 
 ## Lists {#lists}
 
@@ -311,7 +311,7 @@ In general, use big-maps to store large amounts of data.
 ### Implementation details
 
 - Michelson: [Operations on lists](https://tezos.gitlab.io/active/michelson.html#operations-on-lists)
-- SmartPy: [Lists](https://smartpy.io/manual/syntax/lists-sets-and-maps#lists)
+- SmartPy: [Lists, sets, and maps](https://smartpy.io/manual/data-types/lists-sets-and-maps)
 - Archetype: [List](https://archetype-lang.org/docs/language-basics/container#list)
 - LIGO: [List](https://ligolang.org/docs/reference/list-reference)
 
@@ -333,7 +333,7 @@ The main operations available on sets are:
 
 - Michelson: [Operations on sets](https://tezos.gitlab.io/active/michelson.html#operations-on-sets)
 - Archetype: [Set](https://archetype-lang.org/docs/language-basics/container#set)
-- SmartPy: [Sets](https://smartpy.io/manual/syntax/lists-sets-and-maps#sets)
+- SmartPy: [Lists, sets, and maps](https://smartpy.io/manual/data-types/lists-sets-and-maps)
 - LIGO: [Set](https://ligolang.org/docs/reference/set-reference)
 
 ## Variants and Unions {#variants}
@@ -349,7 +349,7 @@ For example, a variant can hold either an `int` or a `string`.
 
 - Michelson: [Operations on unions](https://tezos.gitlab.io/active/michelson.html#operations-on-unions)
 - LIGO: [Variant types](https://ligolang.org/docs/language-basics/unit-option-pattern-matching#variant-types)
-- SmartPy: [Variants](https://smartpy.io/manual/syntax/options-and-variants#variants)
+- SmartPy: [Options and variants](https://smartpy.io/manual/data-types/options-and-variants)
 - Archetype: [Enum](https://archetype-lang.org/docs/language-basics/composite#enum)
 
 ## Lambdas {#lambdas}
@@ -464,7 +464,7 @@ Contracts can run these operations on tickets:
 - Michelson: [Operations on tickets](https://tezos.gitlab.io/active/michelson.html#operations-on-tickets)
 - LIGO: [Tickets](https://ligolang.org/docs/reference/current-reference#tickets)
 - Archetype: [create_ticket and related](https://archetype-lang.org/docs/reference/expressions/builtins/#create_ticket%28s%20:%20T,%20n%20:%20nat%29)
-- SmartPy: [Tickets](https://smartpy.io/manual/syntax/tickets)
+- SmartPy: [Tickets](https://smartpy.io/manual/data-types/tickets)
 
 ## Unit {#unit}
 
@@ -489,4 +489,4 @@ Unit is a concept that Tezos inherits from OCaml; see [Side-Effects and the unit
 
 - LIGO: [Unit](https://ligolang.org/docs/next/data-types/variants#unit)
 - Archetype: [Unit](https://archetype-lang.org/docs/reference/types/#unit)
-- SmartPy: [Unit](https://smartpy.io/manual/syntax/unit)
+- SmartPy: [Unit](https://smartpy.io/manual/data-types/unit)

--- a/docs/smart-contracts/data-types/complex-data-types.md
+++ b/docs/smart-contracts/data-types/complex-data-types.md
@@ -285,7 +285,7 @@ Here is a table representing an example of a contract that uses two big-maps:
 - Michelson: [Operations on big-maps](https://tezos.gitlab.io/active/michelson.html#operations-on-big-maps)
 - Archetype: [Assets](https://archetype-lang.org/docs/reference/instructions/asset), [Map](https://archetype-lang.org/docs/language-basics/container#map)
 - LIGO: [Maps](https://ligolang.org/docs/language-basics/maps-records#maps), [Big-maps](https://ligolang.org/docs/language-basics/maps-records#big-maps)
-- SmartPy: [Lists, sets, and maps](https://smartpy.io/manual/data-types/lists-sets-and-maps)
+- SmartPy: [Maps](https://smartpy.io/manual/data-types/lists-sets-and-maps#maps)
 
 ## Lists {#lists}
 
@@ -311,7 +311,7 @@ In general, use big-maps to store large amounts of data.
 ### Implementation details
 
 - Michelson: [Operations on lists](https://tezos.gitlab.io/active/michelson.html#operations-on-lists)
-- SmartPy: [Lists, sets, and maps](https://smartpy.io/manual/data-types/lists-sets-and-maps)
+- SmartPy: [List](https://smartpy.io/manual/data-types/lists-sets-and-maps#lists)
 - Archetype: [List](https://archetype-lang.org/docs/language-basics/container#list)
 - LIGO: [List](https://ligolang.org/docs/reference/list-reference)
 
@@ -333,7 +333,7 @@ The main operations available on sets are:
 
 - Michelson: [Operations on sets](https://tezos.gitlab.io/active/michelson.html#operations-on-sets)
 - Archetype: [Set](https://archetype-lang.org/docs/language-basics/container#set)
-- SmartPy: [Lists, sets, and maps](https://smartpy.io/manual/data-types/lists-sets-and-maps)
+- SmartPy: [Set](https://smartpy.io/manual/data-types/lists-sets-and-maps#sets)
 - LIGO: [Set](https://ligolang.org/docs/reference/set-reference)
 
 ## Variants and Unions {#variants}

--- a/docs/smart-contracts/data-types/crypto-data-types.md
+++ b/docs/smart-contracts/data-types/crypto-data-types.md
@@ -34,7 +34,7 @@ It can also be used for identity-based cryptography, single-round multi-party ke
 - Michelson: [Cryptographic primitives](https://tezos.gitlab.io/active/michelson.html#cryptographic-primitives), [BLS12-381 primitives](https://tezos.gitlab.io/active/michelson.html#bls12-381-primitives)
 - LIGO: [Crypto](https://ligolang.org/docs/reference/crypto-reference)
 - Archetype: [Blake2b and related](https://archetype-lang.org/docs/reference/expressions/builtins#blake2b%28b%20:%20bytes%29), [Elliptic curves](https://archetype-lang.org/docs/language-basics/crypto#elliptic-curves)
-- SmartPy: [Cryptography](https://smartpy.io/manual/scenarios/cryptography#cryptography)
+- SmartPy: [BLS12-381 ](https://smartpy.io/manual/data-types/bls12-381)
 - Taquito: [Signing data](https://tezostaquito.io/docs/signing/)
 
 ## Time-locks

--- a/docs/smart-contracts/data-types/primitive-data-types.md
+++ b/docs/smart-contracts/data-types/primitive-data-types.md
@@ -22,7 +22,7 @@ For a complete list of data types that are available, see the reference informat
 - Michelson: [Types](https://tezos.gitlab.io/michelson-reference/#types)
 - LIGO: [Introduction](https://ligolang.org/docs/intro/introduction?lang=jsligo)
 - Archetype: [Types](https://archetype-lang.org/docs/reference/types)
-- SmartPy: [Overview](https://smartpy.io/manual/syntax/overview)
+- SmartPy: [Overview](https://smartpy.io/manual/introduction/overview)
 
 ## Numeric data types: `int` and `nat` {#numeric}
 
@@ -187,5 +187,5 @@ See these links for technical information about how different languages handle d
 
 - Michelson: [int and nat](https://tezos.gitlab.io/active/michelson.html#operations-on-integers-and-natural-numbers), [booleans](https://tezos.gitlab.io/active/michelson.html#operations-on-booleans), [strings](https://tezos.gitlab.io/active/michelson.html#operations-on-strings), [timestamps](https://tezos.gitlab.io/active/michelson.html#operations-on-timestamps), [mutez](https://tezos.gitlab.io/active/michelson.html#operations-on-mutez).
 - Archetype: [Types basics](https://archetype-lang.org/docs/language-basics/types), [Types](https://archetype-lang.org/docs/reference/types), [Arithmetic operators](https://archetype-lang.org/docs/reference/expressions/operators/arithmetic)
-- SmartPy: [Integers and mutez](https://smartpy.io/manual/syntax/integers-and-mutez), [Booleans](https://smartpy.io/manual/syntax/booleans), [Strings and Bytes](https://smartpy.io/manual/syntax/strings-and-bytes), [Timestamps](https://smartpy.io/manual/syntax/timestamps)
+- SmartPy: [Integers and mutez](https://smartpy.io/manual/data-types/integers-and-mutez), [Booleans](https://smartpy.io/manual/data-types/booleans), [Strings and Bytes](https://smartpy.io/manual/data-types/strings-and-bytes), [Timestamps](https://smartpy.io/manual/data-types/timestamps)
 - LIGO: [numbers and tez](https://ligolang.org/docs/language-basics/math-numbers-tez), [strings & bytes](https://ligolang.org/docs/language-basics/strings-bytes), [booleans](https://ligolang.org/docs/language-basics/boolean-if-else)

--- a/docs/smart-contracts/delegation.md
+++ b/docs/smart-contracts/delegation.md
@@ -20,4 +20,4 @@ In practice, both the voting power of a contract and the total voting power of a
 
 - Michelson: [Operations on contracts](https://tezos.gitlab.io/active/michelson.html#operations-on-contracts)
 - Archetype: [Total voting power](https://archetype-lang.org/docs/reference/expressions/constants#total_voting_power), [Voting power](https://archetype-lang.org/docs/reference/expressions/builtins#voting_power%28k%20:%20key_hash%29), [set_delegate](https://archetype-lang.org/docs/reference/expressions/builtins#set_delegate%28opkh%20:%20option%3Ckey_hash%3E%29)
-- SmartPy: [Operations](https://smartpy.io/manual/syntax/operations)
+- SmartPy: [Operations](https://smartpy.io/manual/data-types/operations)

--- a/docs/smart-contracts/entrypoints.md
+++ b/docs/smart-contracts/entrypoints.md
@@ -88,5 +88,5 @@ For information about coding entrypoints in specific languages, see these links:
 
 - Michelson: [Entrypoint](https://tezos.gitlab.io/active/michelson.html#entrypoints)
 - Archetype: [Entrypoint](https://archetype-lang.org/docs/reference/declarations/entrypoint)
-- SmartPy: [Contracts](https://smartpy.io/manual/syntax/overview?#contracts)
+- SmartPy: [Contracts](https://smartpy.io/manual/syntax/contracts)
 - LIGO: [Main function and Entrypoints](https://ligolang.org/docs/advanced/entrypoints-contracts)

--- a/docs/smart-contracts/events.md
+++ b/docs/smart-contracts/events.md
@@ -173,6 +173,6 @@ For example, to see the operation in the previous example, look up the operation
 
 - Michelson: [Contract events](https://tezos.gitlab.io/alpha/event.html)
 - LIGO: [Events](https://ligolang.org/docs/contract/events)
-- SmartPy: [`sp.emit`](https://smartpy.io/manual/syntax/operations#sp.emit)
+- SmartPy: [`sp.emit`](https://smartpy.io/manual/syntax/operations)
 - Archetype: [Events](https://archetype-lang.org/blog/events/#event)
 - Taquito: [Contract Events](https://tezostaquito.io/docs/subscribe_event)

--- a/docs/smart-contracts/languages/smartpy.md
+++ b/docs/smart-contracts/languages/smartpy.md
@@ -7,7 +7,7 @@ last_update:
 
 SmartPy is a comprehensive solution for developing, testing, and deploying smart contracts on Tezos. With its easy-to-use Python syntax, developers can create contracts in a familiar and intuitive way, while SmartPy's type inference provides added safety.
 
-To get started with SmartPy, see the tutorial [Deploy a smart contract with SmartPy](/tutorials/smart-contract/smartpy), the [tutorial](https://smartpy.io/guides/tutorial) on smartpy.io, or [Smart contract development with SmartPy](https://opentezos.com/smartpy/write-contract-smartpy/) on opentezos.com.
+To get started with SmartPy, see the tutorial [Deploy a smart contract with SmartPy](/tutorials/smart-contract/smartpy), the [tutorial](https://smartpy.io/tutorial) on smartpy.io, or [Smart contract development with SmartPy](https://opentezos.com/smartpy/write-contract-smartpy/) on opentezos.com.
 
 ## Test scenarios
 
@@ -15,7 +15,7 @@ SmartPy allows you test contracts in simulated scenarios, including complex case
 
 ## FA2 library
 
-SmartPy provides a library of classes that you can extend to create FA2 token contracts. The library provides basic functionality for NFTs, fungible tokens, and single-asset token contracts and mixins that change how the tokens work. For more information, see [FA2lib](https://smartpy.io/guides/FA2-lib/overview) in the SmartPy documentation.
+SmartPy provides a library of classes that you can extend to create FA2 token contracts. The library provides basic functionality for NFTs, fungible tokens, and single-asset token contracts and mixins that change how the tokens work. For more information, see [FA2lib](https://smartpy.io/manual/libraries/FA2-lib/overview) in the SmartPy documentation.
 
 ## Online IDE
 
@@ -71,6 +71,6 @@ def test():
 
 ## Further reading
 
-- [SmartPy documentation](https://smartpy.io/manual/)
+- [SmartPy documentation](https://smartpy.io/manual/introduction/overview)
 - [Online IDE](https://smartpy.dev/ide)
 - [OpenTezos](https://opentezos.com/smartpy)

--- a/docs/smart-contracts/logic/comparing.md
+++ b/docs/smart-contracts/logic/comparing.md
@@ -38,5 +38,5 @@ In Michelson, comparisons are done in two steps:
 
 - Michelson: [Generic comparison](https://tezos.gitlab.io/active/michelson.html#generic-comparison)
 - Archetype: [Comparison operators](https://archetype-lang.org/docs/reference/expressions/operators/arithmetic#a--b-7)
-- SmartPy: [Comparing sp.int and sp.nat](https://smartpy.io/manual/syntax/integers-and-mutez#comparison)
+- SmartPy: [Comparison](https://smartpy.io/manual/data-types/integers-and-mutez#comparison)
 - LIGO: [Comparing values](https://ligolang.org/docs/language-basics/boolean-if-else#comparing-values)

--- a/docs/smart-contracts/logic/errors.md
+++ b/docs/smart-contracts/logic/errors.md
@@ -68,5 +68,5 @@ In particular, the error value is often used when testing  contracts, where the 
   - [FAIL](https://tezos.gitlab.io/active/michelson.html#fail)
   - [Assertion macros](https://tezos.gitlab.io/active/michelson.html#assertion-macros),
 - Archetype: [require](https://archetype-lang.org/docs/reference/declarations/entrypoint/#require), [fail if](https://archetype-lang.org/docs/reference/declarations/entrypoint/#fail-if)
-- SmartPy: [Exceptions](https://smartpy.io/manual/scenarios/testing_contracts#exceptions)
+- SmartPy: [Exceptions](https://smartpy.io/manual/syntax/exceptions)
 - LIGO: [Exceptions](https://ligolang.org/docs/language-basics/exceptions)

--- a/docs/smart-contracts/logic/operations.md
+++ b/docs/smart-contracts/logic/operations.md
@@ -123,4 +123,4 @@ To summarize:
 - Michelson: [Operations on contracts](https://tezos.gitlab.io/active/michelson.html#operations-on-contracts)
 - Archetype: [Operation](https://archetype-lang.org/docs/reference/instructions/operation)
 - LIGO: [Inter-contract invocations](https://ligolang.org/docs/advanced/entrypoints-contracts#inter-contract-invocations)
-- SmartPy: [Operations](https://smartpy.io/manual/syntax/operations)
+- SmartPy: [Operations](https://smartpy.io/manual/data-types/operations)

--- a/docs/smart-contracts/samples.md
+++ b/docs/smart-contracts/samples.md
@@ -11,9 +11,10 @@ Here are some places to find sample smart contacts:
 - For conceptual examples of contracts, see https://opentezos.com/smart-contracts/simplified-contracts/
 - For examples of contracts in LIGO, see https://packages.ligolang.org/contracts
 - For examples of contracts in Archetype, see https://archetype-lang.org/docs/templates/overview
-- For examples of contracts in SmartPy, see https://smartpy.io/guides/examples/
+- For examples of contracts in SmartPy, see the templates in the [SmartPy IDE](https://smartpy.io/ide)
 
 For examples of FA2 smart contracts, see:
 
 - The SmartPy [FA2 library](https://smartpy.io/guides/FA2-lib/overview)
+- The LIGO [`@ligo/fa`](https://packages.ligolang.org/package/@ligo/fa) package
 - [oxheadalpha/smart-contracts](https://github.com/oxheadalpha/smart-contracts)

--- a/docs/smart-contracts/serialization.md
+++ b/docs/smart-contracts/serialization.md
@@ -66,5 +66,5 @@ octez-codec describe alpha.script.expr binary schema
 ## Implementation details
 
 - LIGO: [Pack and Unpack](https://ligolang.org/docs/next/data-types/bytes#packing-and-unpacking)
-- SmartPy: [Packing and Unpacking](https://smartpy.io/manual/syntax/strings-and-bytes#packing-and-unpacking)
+- SmartPy: [Packing and Unpacking](https://smartpy.io/manual/data-types/strings-and-bytes#packing-and-unpacking)
 - Archetype: [pack](https://archetype-lang.org/docs/reference/expressions/builtins#pack%28o%20:%20T%29), [unpack](https://archetype-lang.org/docs/reference/expressions/builtins#unpack%3CT%3E%28b%20:%20bytes%29)

--- a/docs/smart-contracts/special-values.md
+++ b/docs/smart-contracts/special-values.md
@@ -60,5 +60,5 @@ It increments by one for each new block.
 
 - Michelson: [Special operations](https://tezos.gitlab.io/active/michelson.html#special-operations), [Operations on contracts](https://tezos.gitlab.io/active/michelson.html#operations-on-contracts)
 - Archetype: [Constants](https://archetype-lang.org/docs/reference/expressions/constants/#now)
-- SmartPy: [Timestamps](https://smartpy.io/manual/syntax/timestamps)
+- SmartPy: [Timestamps](https://smartpy.io/manual/data-types/timestamps)
 - LIGO: [Tezos](https://ligolang.org/docs/reference/current-reference), [Tezos specific built-ins](https://ligolang.org/docs/advanced/entrypoints-contracts#tezos-specific-built-ins), [Tezos.now](https://ligolang.org/docs/advanced/timestamps-addresses#starting-time-of-the-current-block)

--- a/docs/smart-contracts/storage.md
+++ b/docs/smart-contracts/storage.md
@@ -21,5 +21,5 @@ See [Examples of contracts](https://opentezos.com/smart-contracts/simplified-con
 
 - Michelson: [Semantic of contracts and transactions](https://ligolang.org/docs/advanced/entrypoints-contracts)
 - Archetype: [Storage](https://archetype-lang.org/docs/reference/declarations/storage)
-- SmartPy: [Contracts](https://smartpy.io/manual/syntax/overview#contracts)
+- SmartPy: [Contracts](https://smartpy.io/manual/data-types/contracts)
 - LIGO: [Main function](https://ligolang.org/docs/advanced/entrypoints-contracts)

--- a/docs/smart-contracts/views.md
+++ b/docs/smart-contracts/views.md
@@ -220,6 +220,6 @@ If the view takes no parameters, you can pass Unit or omit the `with input`.
 
 - Octez: [On-chain views](https://tezos.gitlab.io/active/views.html)
 - Archetype: [View](https://archetype-lang.org/docs/reference/declarations/view)
-- SmartPy: [Views in testing](https://smartpy.io/manual/scenarios/testing_contracts#views)
+- SmartPy: [Testing expressions](https://smartpy.io/manual/scenarios/testing_contracts#testing-expressions-views-and-lambdas)
 - LIGO: [On-chain views](https://ligolang.org/docs/protocol/hangzhou#on-chain-views)
 - Taquito: [On-chain views](https://tezostaquito.io/docs/on_chain_views)

--- a/docs/tutorials/smartpy-fa2-fungible/basic-fa2-token.md
+++ b/docs/tutorials/smartpy-fa2-fungible/basic-fa2-token.md
@@ -73,7 +73,7 @@ Follow these steps to create your own token contract based on the `main.Fungible
    ```
 
    Note the order of these classes both in the `class` statement and within the `__init__()` method.
-   You must inherit and initialize these classes in a specific order for them to work, as described in [Mixins](https://smartpy.io/guides/FA2-lib/mixins). <!-- TODO change link when new docs come out -->
+   You must inherit and initialize these classes in a specific order for them to work, as described in [Mixins](https://smartpy.io/manual/libraries/FA2-lib/mixins).
 
 1. Outside the module, add these two utility functions to call views in the contract:
 


### PR DESCRIPTION
The reworked SmartPy docs have some redirects in place but it would be good to update our links to them.

See also https://gitlab.com/nomadic-labs-free-resources/opentezos/-/merge_requests/174.