### PR TITLE
Update baker tutorial to use consensus keys

### DIFF
--- a/docs/tutorials/join-dal-baker/prepare-account.md
+++ b/docs/tutorials/join-dal-baker/prepare-account.md
@@ -1,14 +1,31 @@
 ---
-title: "Step 2: Set up a baker account"
+title: "Step 2: Set up baker accounts"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 19 August 2024
+  date: 31 December 2024
 ---
 
-The baker needs a user account that stakes tez.
-In this section, you use the Octez client to create an account, register it as a delegate, and stake tez with it.
+In this section you use the Octez client to set up two accounts for your baker:
 
-1. Create or import an account in the Octez client.
+- The baker key itself (also called the manager key) stakes tez and registers as a delegate
+- The consensus key is the key that the baker uses to sign attestations, which are generally referred to as _consensus operations_
+
+:::note
+
+Using a separate consensus key is not required but it is good security practice.
+Signing consensus operations incurs no fees, so you can set up a baker with a key that has no tez.
+You can use this key on a remote machine and keep your baker key with the tez in a more secure location to reduce risk to your funds.
+
+If the consensus key is compromised or lost, you can create a new key and switch the baker to it without changing how your tez is staked and delegated and without moving your delegators and stakers to a new account.
+In this way you can avoid backing up the consensus key or store it in a Key Management System (KMS) or Hardware Security Module (HSM) where no one has access to its private key.
+
+For more information about consensus keys, see [Consensus key](https://tezos.gitlab.io/user/key-management.html#consensus-key) in the Octez documentation.
+
+:::
+
+In this section, you use the Octez client to create these two accounts and set them up for baking.
+
+1. Create or import an account in the Octez client to be the baker or manager account.
 The simplest way to get an account is to use the Octez client to randomly generate an account.
 This command creates an account and associates it with the `my_baker` alias:
 
@@ -16,7 +33,7 @@ This command creates an account and associates it with the `my_baker` alias:
    octez-client gen keys my_baker
    ```
 
-   The address of the generated account can be obtained with the following command:
+   You can get the address of the generated account with this command:
 
    ```bash
    octez-client show address my_baker
@@ -47,10 +64,19 @@ This command creates an account and associates it with the `my_baker` alias:
 
    When the account receives its tez, it owns enough stake to bake but has still no consensus or DAL rights because it has not declared its intention to become a baker.
 
-1. Register your account as a delegate by running the following command:
+1. Set up a separate account to be the consensus key.
+This command creates an account and associates it with the `consensus_key` alias:
 
    ```bash
-   octez-client register key my_baker as delegate
+   octez-client gen keys consensus_key
+   ```
+
+   This account does not need any tez.
+
+1. Register the baker account as a delegate and set its consensus key by running the following command:
+
+   ```bash
+   octez-client register key my_baker as delegate with consensus key consensus_key
    ```
 
 1. Stake at least 6,000 tez, saving a small amount for transaction fees, by running this command:
@@ -59,7 +85,8 @@ This command creates an account and associates it with the `my_baker` alias:
    octez-client stake 6000 for my_baker
    ```
 
-Now the account has staked enough tez to earn the right to make attestations, including attestations that data is available on the DAL.
-However, it does not receive these rights until the baking daemon is running and a certain amount of time has passed.
+Now the baker account has staked enough tez to earn the right to make attestations, including attestations that data is available on the DAL.
+Its consensus key is authorized to sign consensus operations on its behalf.
+However, the baker account does not receive these rights until the baking daemon is running and a certain amount of time has passed.
 
 While you wait for attestation rights, continue to [Step 3: Run an Octez DAL node](/tutorials/join-dal-baker/run-dal-node).

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -10,10 +10,17 @@ If you already have a baking daemon, you can restart it to connect to the DAL no
 
 1. Optional: Set up a remote signer to secure the keys that the baker uses as described in [Signer](https://tezos.gitlab.io/user/key-management.html#signer) in the Octez documentation.
 
-1. To run a baking daemon that connects to the DAL, start it as usual and pass the URL to your DAL node to it with the `--dal-node` argument:
+1. Run a baking daemon with the following arguments:
+
+   - Use the consensus key, not the baker key
+   - Pass the URL to your DAL node with the `--dal-node` argument
+   - Pass the `--liquidity-baking-toggle-vote` argument; for more information, see [Liquidity baking](https://tezos.gitlab.io/active/liquidity_baking.html) in the Octez documentation
+   - Pass the `--adaptive-issuance-vote` argument; for more information, see [Adaptive Issuance and Staking](https://tezos.gitlab.io/active/adaptive_issuance.html) in the Octez documentation
+
+   For example:
 
    ```bash
-   octez-baker-PsParisC run with local node "$HOME/.tezos-node" my_baker --liquidity-baking-toggle-vote pass --adaptive-issuance-vote on --dal-node http://127.0.0.1:10732
+   octez-baker-PsParisC run with local node "$HOME/.tezos-node" consensus_key --liquidity-baking-toggle-vote pass --adaptive-issuance-vote on --dal-node http://127.0.0.1:10732
    ```
 
    Note that the command for the baker depends on the protocol version.
@@ -41,7 +48,7 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
    [Service]
    Type=simple
    User=tezos
-   ExecStart=octez-baker-PsParisC run with local node "$HOME/.tezos-node" my_baker --liquidity-baking-toggle-vote pass --adaptive-issuance-vote on --dal-node http://127.0.0.1:10732
+   ExecStart=octez-baker-PsParisC run with local node "$HOME/.tezos-node" consensus_key --liquidity-baking-toggle-vote pass --adaptive-issuance-vote on --dal-node http://127.0.0.1:10732
    WorkingDirectory=/opt/octez-baker
    Restart=on-failure
    RestartSec=5
@@ -132,6 +139,9 @@ For example, if the delay is 307,200 seconds, that time is about 3.5 days.
    These lines log the attestations that the baker makes.
 
    If the baker does not have attestation rights, the log contains lines that start with `The following delegates have no attesting rights at level ...`.
+
+   Note that even though the baker daemon is using the consensus key, the attestations refer to the baker key.
+   The consensus key makes attestations on behalf of the baker key but the baking daemon does not need access to the baker key.
 
 After the attestation delay, whether or not you have attestation rights, proceed to [Step 5: Verifications](/tutorials/join-dal-baker/verify-rights).
 

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -116,12 +116,12 @@ For example, if the delay is 307,200 seconds, that time is about 3.5 days.
 
    The exact time depends on what time in the current cycle the account staked its tez.
 
-:::note
+   :::note
 
-The amount of tez that the account stakes determines how often it is called on to make attestations, not how quickly it receives rights.
-Therefore, staking more tez brings more rewards but does not reduce the attestation delay.
+   The amount of tez that the account stakes determines how often it is called on to make attestations, not how quickly it receives rights.
+   Therefore, staking more tez brings more rewards but does not reduce the attestation delay.
 
-:::
+   :::
 
 1. After the delay computed above has passed, **the baker log** (not the Octez node log, neither the DAL node log) should contain lines about:
 

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -2,7 +2,7 @@
 title: "Step 4: Run an Octez baking daemon"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 19 December 2024
+  date: 31 December 2024
 ---
 
 Now that you have a layer 1 node and a DAL node, you can run a baking daemon that can create blocks and attests to DAL data.
@@ -123,13 +123,17 @@ For example, if the delay is 307,200 seconds, that time is about 3.5 days.
 
    :::
 
-1. After the delay computed above has passed, **the baker log** (not the Octez node log, neither the DAL node log) should contain lines about:
+1. After the delay computed above has passed, **the baker log** (not the Octez node log, neither the DAL node log) should contain lines that look like this:
 
-- Consensus pre-attestations: `injected preattestation ...`
-- Consensus attestations: `injected attestation ...`
-- Attach DAL attestations: `ready to attach DAL attestation ...`
+   - Consensus pre-attestations: `injected preattestation ...`
+   - Consensus attestations: `injected attestation ...`
+   - Attach DAL attestations: `ready to attach DAL attestation ...`
 
-Whether these messages appear or not after the attestation delay, proceed to [Step 5: Verifications](/tutorials/join-dal-baker/verify-rights).
+   These lines log the attestations that the baker makes.
+
+   If the baker does not have attestation rights, the log contains lines that start with `The following delegates have no attesting rights at level ...`.
+
+After the attestation delay, whether or not you have attestation rights, proceed to [Step 5: Verifications](/tutorials/join-dal-baker/verify-rights).
 
 ## Optional: Run an accuser
 

--- a/docs/tutorials/join-dal-baker/run-node.md
+++ b/docs/tutorials/join-dal-baker/run-node.md
@@ -128,4 +128,4 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
 1. Optional: When the node has bootstrapped and caught up with the current head block, you can delete the snapshot file to save space.
 
 In the meantime, you can continue the baking infrastructure while the node is bootstrapping.
-Continue to [Step 2: Set up a baker account](/tutorials/join-dal-baker/prepare-account).
+Continue to [Step 2: Set up baker accounts](/tutorials/join-dal-baker/prepare-account).

--- a/docs/tutorials/join-dal-baker/verify-rights.md
+++ b/docs/tutorials/join-dal-baker/verify-rights.md
@@ -140,6 +140,30 @@ If you don't see DAL attestation rights:
 
    - Verify that your DAL node is connected to the network by following the instructions in [Troubleshooting](https://tezos.gitlab.io/shell/dal_run.html#troubleshooting) in the Octez documentation.
 
+## Optional: Changing the consensus key
+
+If you need to change the consensus key that the baker daemon uses, you can change it without changing the baker key.
+The new key takes effect after the same attestation delay that you had to wait for your baker to receive attestation rights when you first set it up:
+
+```
+(consensus_rights_delay + 2) * blocks_per_cycle * minimal_block_delay
+```
+
+Follow these steps to change the consensus key:
+
+1. Generate a new consensus key with the `octez-client gen keys` command or import a private key into the instance of the Octez client on the same machine as the baking daemon.
+
+1. Use this new key as the consensus key for your baker account by running this command, with the address or alias of the new consensus key as the `<NEW CONSENSUS KEY>` variable:
+
+   ```bash
+   octez-client set consensus key for my_baker to <NEW CONSENSUS KEY>
+   ```
+
+1. Wait for the change to take effect.
+During this time you can leave the baking daemon running with the old consensus key.
+
+1. When the new consensus key is active, stop the baking daemon and restart it with the new consensus key.
+
 ## Optional: Unstaking your tez and receiving your baking rewards
 
 If you leave the baker running, you can see rewards accrue by running the command `octez-client get staked balance for my_baker`.

--- a/docs/tutorials/join-dal-baker/verify-rights.md
+++ b/docs/tutorials/join-dal-baker/verify-rights.md
@@ -2,12 +2,12 @@
 title: "Step 5: Verifications"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 2 December 2024
+  date: 31 December 2024
 ---
 
 After the delay that you calculated in [Step 4: Run an Octez baking daemon](/tutorials/join-dal-baker/run-baker), follow these instructions to verify the activity or diagnose and fix issues.
 
-1. Record the address of your baker account in an environment variable so you can use it for commands that cannot get addresses by their Octez client aliases:
+1. Record the address of your baker account (not the consensus account)in an environment variable so you can use it for commands that cannot get addresses by their Octez client aliases:
 
    ```bash
    MY_BAKER="$(octez-client show address my_baker | head -n 1 | cut -d ' ' -f 2)"
@@ -50,7 +50,7 @@ After the delay that you calculated in [Step 4: Run an Octez baking daemon](/tut
 
    - Otherwise, make sure that your node and baker are running.
 
-   - Verify that the staked balance of your account is at least 6,000 tez by running the command `octez-client get staked balance for my_baker`.
+   - Verify that the staked balance of your baker account is at least 6,000 tez by running the command `octez-client get staked balance for my_baker`.
    If the response is less than 6,000 tez, you have not staked enough.
    Ensure that you are registered as a delegate and stake more tez, retaining a small amount for transaction fees.
    If necessary you can get more from the faucet.
@@ -68,7 +68,7 @@ After the delay that you calculated in [Step 4: Run an Octez baking daemon](/tut
       1. If the value for the `deactivated` field is `true`, re-register as a baker by running this command:
 
          ```bash
-         octez-client register key my_baker as delegate
+         octez-client register key my_baker as delegate with consensus key consensus_key
          ```
 
       When the next cycle starts, Tezos calculates attestation rights for two cycles in the future and includes your baker.
@@ -124,7 +124,7 @@ After the delay that you calculated in [Step 4: Run an Octez baking daemon](/tut
    l=<current-level>; while true; echo $l; do octez-client rpc get "/chains/main/blocks/head/context/dal/shards?delegates=$MY_BAKER&level=$l"; l=$((l+1)); done
    ```
 
-1. Verify the baker's activity on the Explorus block explorer by going to the Consensus Ops page at https://explorus.io/consensus_ops, selecting Ghostnet, and searching for your address (only the first few characters).
+1. Verify the baker's activity on the Explorus block explorer by going to the Consensus Ops page at https://explorus.io/consensus_ops, selecting Ghostnet, and searching for your baker account address (only the first few characters).
 
    For example, this screenshot shows consensus operations that include DAL attestations, indicated by a number in the "DAL attestation bitset" column.
 


### PR DESCRIPTION
It's better security practice to use a consensus key to sign consensus operations. Update the tutorial:
- Create two keys and explain why
- Use the consensus key to sign operations
- Include a section on changing the key