### PR TITLE
Always load all MD files to check for images

### DIFF
--- a/test/images.test.mjs
+++ b/test/images.test.mjs
@@ -139,7 +139,9 @@ const getImagesInAst = (ast, /*filePath*/) => {
 
 // Get a list of images used in all files
 const getAllUsedImages = async () => {
-  const imagesUsedInDocs = await filePaths.reduce(async (imageListPromise, filePath) => {
+  // Get all files, not files that may be limited by argv.filesToCheck
+  const allMDFiles = await glob(docsFolder + '/**/*.{md,mdx}');
+  const imagesUsedInDocs = await allMDFiles.reduce(async (imageListPromise, filePath) => {
     const imageList = await imageListPromise;
     const ast = await getAst(filePath);
     const imagesInAst = getImagesInAst(ast, filePath);


### PR DESCRIPTION
The image test is failing when combined with the checkChangedFiles action. The `getAllUsedImages` function needs to get all images in all MD files, not just the MD files that were changed in the PR.

To test, check out the main branch and check for missing images in only one file with this command. It returns errors about unused images:
```bash
npm run test -- --filesToCheck=docs/architecture.md
```

Then load this branch, run  the same command, and see that the test passes.