### PR TITLE
Provide example systemd file names and commands

### DIFF
--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -53,7 +53,7 @@ These services must run at all times with a stable power source and internet con
 
 If you don't have enough tez to become a baker or don't want to run a baking node, you can choose a baker as your delegate, which makes you a _delegator_.
 The delegate doesn't have control over your tez and you can spend your tez at any time or withdraw your delegation, but one-third of the tez that you delegate counts toward the baking power of the delegate.
-Similarly, delegated tez increase the voting power of your baker: a delegate's voting power is the sum of its own tez plus all of the tez delegated to it.
+Similarly, delegated tez increase the voting power of your baker: a delegate's voting power is the sum of its own tez plus one-third of the tez delegated to it.
 
 In exchange, delegates may share some part of their rewards with you, in proportion to the amount of available tez in your account (technically, the minimal balance during each cycle).
 Check your delegate's conditions for distributing rewards.
@@ -82,7 +82,7 @@ In summary, here is a comparison between the staking and delegating options abov
 &nbsp; | Staking | Delegating
 --- | --- | ---
 Increase baking power | 100% | 33%
-Increase voting power | 100% | 100%
+Increase voting power | 100% | 33%
 Reward delay | None | 2 cycles (about 6 days)
 Reward route | Direct to staker | To baker who manually sends to delegator
 Funds availability | Frozen (locked) | Liquid (unlocked)

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -53,7 +53,7 @@ These services must run at all times with a stable power source and internet con
 
 If you don't have enough tez to become a baker or don't want to run a baking node, you can choose a baker as your delegate, which makes you a _delegator_.
 The delegate doesn't have control over your tez and you can spend your tez at any time or withdraw your delegation, but one-third of the tez that you delegate counts toward the baking power of the delegate.
-Similarly, delegated tez increase the voting power of your baker: a delegate's voting power is the sum of its own tez plus one-third of the tez delegated to it.
+Similarly, delegated tez increase the voting power of your baker: a delegate's voting power is the sum of its own tez plus all of the tez delegated to it.
 
 In exchange, delegates may share some part of their rewards with you, in proportion to the amount of available tez in your account (technically, the minimal balance during each cycle).
 Check your delegate's conditions for distributing rewards.
@@ -82,7 +82,7 @@ In summary, here is a comparison between the staking and delegating options abov
 &nbsp; | Staking | Delegating
 --- | --- | ---
 Increase baking power | 100% | 33%
-Increase voting power | 100% | 33%
+Increase voting power | 100% | 100%
 Reward delay | None | 2 cycles (about 6 days)
 Reward route | Direct to staker | To baker who manually sends to delegator
 Funds availability | Frozen (locked) | Liquid (unlocked)

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -57,7 +57,7 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
    SyslogIdentifier=%n
    ```
 
-   If you name this service file `/etc/systemd/system/octez-baker-PsQuebec`, you can start it by running these commands:
+   If you name this service file `/etc/systemd/system/octez-baker-PsQuebec.service`, you can start it by running these commands:
 
    ```bash
    sudo systemctl daemon-reload

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -2,7 +2,7 @@
 title: "Step 4: Run an Octez baking daemon"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 14 January 2025
+  date: 15 January 2025
 ---
 
 Now that you have a layer 1 node and a DAL node, you can run a baking daemon that can create blocks and attests to DAL data.
@@ -35,9 +35,9 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
 
    For example, if your operating system uses the `systemd` software suite, your service file might look like this example:
 
-   ```systemd
+   ```systemd title="/etc/systemd/system/octez-baker-PsQuebec.service"
    [Unit]
-   Description=Octez baker
+   Description=Octez baker PsQuebec
    Wants=network-online.target
    After=network-online.target
    Requires=octez-node.service
@@ -55,6 +55,19 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
    StandardOutput=append:/opt/octez-baker.log
    StandardError=append:/opt/octez-baker.log
    SyslogIdentifier=%n
+   ```
+
+   If you name this service file `/etc/systemd/system/octez-baker-PsQuebec`, you can start it by running these commands:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl start octez-baker-PsQuebec.service
+   ```
+
+   You can stop it by running this command:
+
+   ```bash
+   sudo systemctl stop octez-baker-PsQuebec.service
    ```
 
 1. In the same terminal window, run this command:
@@ -174,9 +187,9 @@ You don't have to run an accuser, but if you do, you can receive as a reward par
 Like the baker, the command for the accuser has the protocol name at the end.
 For example, if your operating system uses the `systemd` software suite, the attester service file might look like this example:
 
-```systemd
+```systemd title="/etc/systemd/system/octez-accuser-PsQuebec.service"
 [Unit]
-Description=Octez accuser
+Description=Octez accuser PsQuebec
 Wants=network-online.target
 After=network-online.target
 Requires=octez-node.service

--- a/docs/tutorials/join-dal-baker/run-node.md
+++ b/docs/tutorials/join-dal-baker/run-node.md
@@ -2,7 +2,7 @@
 title: "Step 1: Run an Octez node"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 9 January 2025
+  date: 15 January 2025
 ---
 
 The first thing you need is a Tezos layer 1 node, which is an instance of the `octez-node` program and part of the Octez suite of programs.
@@ -108,7 +108,7 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
 
    For example, if your operating system uses the `systemd` software suite, your service file might look like this example:
 
-   ```systemd
+   ```systemd title="/etc/systemd/system/octez-node.service"
    [Unit]
    Description=Octez node
    Wants=network-online.target
@@ -127,6 +127,19 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
    StandardOutput=append:/opt/octez-node.log
    StandardError=append:/opt/octez-node.log
    SyslogIdentifier=%n
+   ```
+
+   If you name this service file `/etc/systemd/system/octez-node`, you can start it by running these commands:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl start octez-node.service
+   ```
+
+   You can stop it by running this command:
+
+   ```bash
+   sudo systemctl stop octez-node.service
    ```
 
 1. Optional: When the node has bootstrapped and caught up with the current head block, you can delete the snapshot file to save space.

--- a/docs/tutorials/join-dal-baker/run-node.md
+++ b/docs/tutorials/join-dal-baker/run-node.md
@@ -129,7 +129,7 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
    SyslogIdentifier=%n
    ```
 
-   If you name this service file `/etc/systemd/system/octez-node`, you can start it by running these commands:
+   If you name this service file `/etc/systemd/system/octez-node.service`, you can start it by running these commands:
 
    ```bash
    sudo systemctl daemon-reload

--- a/docs/tutorials/join-dal-baker/run-node.md
+++ b/docs/tutorials/join-dal-baker/run-node.md
@@ -2,7 +2,7 @@
 title: "Step 1: Run an Octez node"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 15 January 2025
+  date: 17 January 2025
 ---
 
 The first thing you need is a Tezos layer 1 node, which is an instance of the `octez-node` program and part of the Octez suite of programs.
@@ -141,6 +141,22 @@ You can also refer to [Run a persistent baking node](https://opentezos.com/node-
    ```bash
    sudo systemctl stop octez-node.service
    ```
+
+   The `systemd` software suite uses the `journalctl` program for logging, so you can use it to monitor the node and the other Octez daemons you run.
+   For example, this command prints the log of the Octez node service as it is updated, similar to the `tail -f` command:
+
+   ```bash
+   journalctl --follow --unit=octez-node.service
+   ```
+
+   The `journalctl` program has options that let you search logs during time periods.
+   For example, this command shows log entries between two times:
+
+   ```bash
+   journalctl --unit=octez-baker.service --since "20 minutes ago" --until "60 seconds ago"
+   ```
+
+   For more information about logging, see the documentation for the `journalctl` program.
 
 1. Optional: When the node has bootstrapped and caught up with the current head block, you can delete the snapshot file to save space.
 


### PR DESCRIPTION
- Use protocol-specific file names and service names for systemd services because during upgrade you'll have two bakers and two accusers running
- Provide example file names and example commands for using the service files with systemd