### PR TITLE
Update staking page based on OpenTezos page on delegating

### DIFF
--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -22,7 +22,7 @@ The baking process includes many steps that Tezos users and developers don't nee
 1. It also selects a list of bakers to act as validators.
 These bakers are responsible for validating the blocks that other bakers create and publishing _attestations_ that the block is valid.
 1. The first baker on the list has a certain amount of time (called a round) to create the next block.
-It packages pending operations into a block, signs it, and distributes it to other nodes.
+It packages pending operations from the mempool into a block, signs it, and distributes it to other nodes.
 1. If the first baker doesn't publish a block in time, the next baker on the list has a certain amount of time to bake a block (a new round), and so on until a block is created.
 1. The validators verify the block and publish their attestations in future blocks.
 1. The next list of bakers create the next block, until the end of the cycle.

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -57,8 +57,7 @@ In older versions of the Tezos protocol, before users could stake with a baker, 
 Users delegated their accounts to a baker and in return the baker could choose to share some of their baking rewards with their delegators.
 The rewards to delegators were distributed by the bakers, with no guarantee from the Tezos protocol.
 
-Delegating still works in this way, but currently, the primary use of delegating is as the first step in staking.
-To stake with a baker, users must first choose the baker as their delegate.
+Delegating still works in this way, but currently, it's mostly seen as a preliminary step required for staking.
 Then the system provides the staker with rewards automatically.
 
 ## Staking with a baker

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -53,7 +53,7 @@ These daemons must run at all times with a stable power source and internet conn
 
 ## Delegating to a baker
 
-In older versions of the Tezos protocol, before non-baker users could stake, delegating was the primary way that users earned rewards from tez.
+In older versions of the Tezos protocol, before users could stake with a baker, delegating was the primary way that users earned rewards for their tez.
 Users delegated their accounts to a baker and in return the baker could choose to share some of their baking rewards with their delegators.
 The Tezos system did not automatically provide rewards to delegators.
 

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -2,7 +2,7 @@
 title: Bakers
 authors: "Tim McMackin"
 last_update:
-  date: 13 January 2025
+  date: 16 January 2025
 ---
 
 Baking is the process of creating new blocks in the Tezos blockchain.
@@ -51,31 +51,12 @@ The voting power of a delegate is computed in a similar way to the baking power 
 Bakers must run at least one Tezos node and a baker daemon to go with it.
 These daemons must run at all times with a stable power source and internet connection, because periods of inactivity for a baker entail losses of rewards, and eventually being marked as inactive and temporarily excluded from baking.
 
-## Delegating to a baker
-
-If you don't have enough tez to become a baker or don't want to run a baking node, you can choose a baker as your delegate, which makes you a _delegator_.
-The delegate doesn't have control over your tez and you can spend your tez at any time or withdraw your delegation, but one-third of the tez that you delegate counts toward the baking power of the delegate.
-Similarly, delegated tez increase the voting power of your baker: a delegate's voting power is the sum of its own tez plus all of the tez delegated to it.
-
-In exchange, delegates may share some part of their rewards with you, in proportion to the amount of available tez in your account (technically, the minimal balance during each cycle).
-Check your delegate's conditions for distributing rewards.
-
-Delegating incurs no risk for the delegator: the delegate has no control over the tez and the delegator is not punished if the delegate misbehaves.
-
 ## Staking with a baker
 
-If you want to get a bigger share of your delegate's rewards, you can temporarily stake any amount of tez from your account with your baker, provided your baker accepts staking.
-All the tez you stake don't leave your account: they are frozen in your account,
-but contribute to the baker's security deposit, and are locked under the same conditions as the baker's own staked tez. Hence, they are slashed if the baker misbehaves.
-In exchange of agreeing to temporarily lock these tez and sharing the risks with your delegate, you get a bigger share of the delegate's rewards.
-Staking rewards accrue automatically, and are allocated by the protocol: stakers earn rewards whenever their bakers do, and don't have to wait for the baker to distribute them (unlike delegation rewards).
+If you don't have enough tez to become a baker or don't want to run a baking node, you can choose a baker as your delegate, which makes you a _delegator_.
+Then you can stake tez with that baker and receive a share of the baker's rewards.
 
-Later on, you may choose to unstake part or all of the staked tez, that will be unlocked after a certain delay.
-
-To stake tez, you start by delegating to a baker's account (which should accepts staking and not be "overstaked"), then you stake a certain amount of your tez to the baker.
-Thus, you can earn staking rewards on some frozen tez while leaving some delegated tez liquid for immediate use.
-
-Since you may have only one delegate, you can only stake with one baker at a time.
+For instructions on staking, see [Staking](/using/staking).
 
 ## Summary
 

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -58,7 +58,7 @@ Users delegated their accounts to a baker and in return the baker could choose t
 The rewards to delegators were distributed by the bakers, with no guarantee from the Tezos protocol.
 
 Delegating still works in this way, but currently, it's mostly seen as a preliminary step required for staking.
-Then the system provides the staker with rewards automatically.
+In return, the Tezos protocol provides stakers with rewards automatically.
 
 ## Staking with a baker
 

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -12,6 +12,8 @@ Bakers validate pending operations, package them into a block, sign the block, p
 Baker executables are run on behalf of user accounts.
 By extension, bakers also denote the users running baker daemons on behalf of their user accounts.
 
+For instructions on becoming a baker, see [Run a Tezos node in 5 steps](/tutorials/join-dal-baker).
+
 ## The baking process
 
 The baking process includes many steps that Tezos users and developers don't need to think about, but at a basic level, baking a block follows these steps:

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -55,7 +55,7 @@ These daemons must run at all times with a stable power source and internet conn
 
 In older versions of the Tezos protocol, before users could stake with a baker, delegating was the primary way that users earned rewards for their tez.
 Users delegated their accounts to a baker and in return the baker could choose to share some of their baking rewards with their delegators.
-The Tezos system did not automatically provide rewards to delegators.
+The rewards to delegators were distributed by the bakers, with no guarantee from the Tezos protocol.
 
 Delegating still works in this way, but currently, the primary use of delegating is as the first step in staking.
 To stake with a baker, users must first choose the baker as their delegate.

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -2,7 +2,7 @@
 title: Bakers
 authors: "Tim McMackin"
 last_update:
-  date: 16 January 2025
+  date: 24 January 2025
 ---
 
 Baking is the process of creating new blocks in the Tezos blockchain.
@@ -50,6 +50,16 @@ The voting power of a delegate is computed in a similar way to the baking power 
 
 Bakers must run at least one Tezos node and a baker daemon to go with it.
 These daemons must run at all times with a stable power source and internet connection, because periods of inactivity for a baker entail losses of rewards, and eventually being marked as inactive and temporarily excluded from baking.
+
+## Delegating to a baker
+
+In older versions of the Tezos protocol, before non-baker users could stake, delegating was the primary way that users earned rewards from tez.
+Users delegated their accounts to a baker and in return the baker could choose to share some of their baking rewards with their delegators.
+The Tezos system did not automatically provide rewards to delegators.
+
+Delegating still works in this way, but currently, the primary use of delegating is as the first step in staking.
+To stake with a baker, users must first choose the baker as their delegate.
+Then the system provides the staker with rewards automatically.
 
 ## Staking with a baker
 

--- a/docs/architecture/bakers.md
+++ b/docs/architecture/bakers.md
@@ -48,8 +48,8 @@ The delegate must have a baking power of at least 6,000 tez to be allowed to bak
 A delegate also participates in [governance](/architecture/governance) in proportion to their _voting power_.
 The voting power of a delegate is computed in a similar way to the baking power except that no distinction is made between tez that are staked or not staked.
 
-Bakers must run at least one Tezos node and a baker service to go with it, see our [tutorial for bakers](/tutorials/join-dal-baker).
-These services must run at all times with a stable power source and internet connection, because periods of inactivity for a baker entail losses of rewards, and eventually being marked as inactive and temporarily excluded from baking.
+Bakers must run at least one Tezos node and a baker daemon to go with it.
+These daemons must run at all times with a stable power source and internet connection, because periods of inactivity for a baker entail losses of rewards, and eventually being marked as inactive and temporarily excluded from baking.
 
 ## Delegating to a baker
 

--- a/docs/tutorials/join-dal-baker.md
+++ b/docs/tutorials/join-dal-baker.md
@@ -2,7 +2,7 @@
 title: Run a Tezos node in 5 steps
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 18 December 2024
+  date: 16 January 2025
 ---
 
 As described in [Nodes](/architecture/nodes), Tezos nodes are peer-to-peer programs that run the Tezos network.
@@ -67,6 +67,17 @@ The following diagram shows these daemons with a blue background:
 
 To run the Octez daemons persistently, you need a cloud-based computer or a computer that stays running constantly.
 For other system requirements, see the documentation for the latest release of the Octez suite here: https://tezos.gitlab.io/releases/latest.html.
+
+## Other options for running a baker
+
+These instructions are for baking with the Octez suite programs.
+Other tools can help you set up a baker, but they are not covered in these instructions.
+Here are some of these tools:
+
+- [BakeBuddy and Ledger Nano](https://www.bakebuddy.xyz/): An intuitive plug-and-use method for setting up a node and baker
+- [Kiln and Ledger Nano](https://gitlab.com/tezos-kiln/kiln): An intuitive plug-and-use method for setting up a node and baker
+- [Remote Signer and Ledger Nano](https://github.com/obsidiansystems/ledger-app-tezos)
+- [Signatory's remote Signer via the Cloud](https://www.ecadlabs.com/signatory)
 
 ## References
 

--- a/docs/tutorials/join-dal-baker.md
+++ b/docs/tutorials/join-dal-baker.md
@@ -2,7 +2,7 @@
 title: Run a Tezos node in 5 steps
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 16 January 2025
+  date: 23 January 2025
 ---
 
 As described in [Nodes](/architecture/nodes), Tezos nodes are peer-to-peer programs that run the Tezos network.
@@ -17,6 +17,12 @@ This tutorial covers setting up a Tezos node as a baker, which includes running 
 - An Octez node, sometimes referred to as a Tezos node
 - A baker daemon
 - A [DAL](/architecture/data-availability-layer) node
+
+:::note
+
+If you want to use a Ledger hardware wallet to secure your keys, see [Bake using a Ledger device](/tutorials/bake-with-ledger).
+
+:::
 
 ## Why is a DAL node needed?
 
@@ -76,7 +82,6 @@ Here are some of these tools:
 
 - [BakeBuddy and Ledger Nano](https://www.bakebuddy.xyz/): An intuitive plug-and-use method for setting up a node and baker
 - [Kiln and Ledger Nano](https://gitlab.com/tezos-kiln/kiln): An intuitive plug-and-use method for setting up a node and baker
-- [Remote Signer and Ledger Nano](https://github.com/obsidiansystems/ledger-app-tezos)
 - [Signatory's remote Signer via the Cloud](https://www.ecadlabs.com/signatory)
 
 ## References

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -2,7 +2,7 @@
 title: "Step 4: Run an Octez baking daemon"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 16 January 2025
+  date: 23 January 2025
 ---
 
 Now that you have a layer 1 node and a DAL node, you can run a baking daemon that can create blocks and attests to DAL data.
@@ -13,7 +13,6 @@ If you already have a baking daemon, you can restart it to connect to the DAL no
 Be sure to run only one baking daemon per Tezos account.
 If you run more than one, you risk double-baking or double-attesting and being slashed.
 However, it is safe to run two baking daemons during the protocol upgrade process because one daemon uses the previous protocol and the other daemon uses the new protocol.
-For ways to ensure the reliability of your baking setup that does not involve running multiple baker daemons, see [Inactive delegates](https://tezos.gitlab.io/introduction/howtorun.html#inactive-delegates) in the Octez documentation.
 
 :::
 

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -2,11 +2,20 @@
 title: "Step 4: Run an Octez baking daemon"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 15 January 2025
+  date: 16 January 2025
 ---
 
 Now that you have a layer 1 node and a DAL node, you can run a baking daemon that can create blocks and attests to DAL data.
 If you already have a baking daemon, you can restart it to connect to the DAL node.
+
+:::warning Run one baker per account
+
+Be sure to run only one baking daemon per Tezos account.
+If you run more than one, you risk double-baking or double-attesting and being slashed.
+However, it is safe to run two baking daemons during the protocol upgrade process because one daemon uses the previous protocol and the other daemon uses the new protocol.
+For ways to ensure the reliability of your baking setup that does not involve running multiple baker daemons, see [Inactive delegates](https://tezos.gitlab.io/introduction/howtorun.html#inactive-delegates) in the Octez documentation.
+
+:::
 
 1. Optional: Set up a remote signer to secure the keys that the baker uses as described in [Signer](https://tezos.gitlab.io/user/key-management.html#signer) in the Octez documentation.
 

--- a/docs/using/staking.md
+++ b/docs/using/staking.md
@@ -2,7 +2,7 @@
 title: Staking
 authors: "Tim McMackin"
 last_update:
-  date: 15 January 2025
+  date: 16 January 2025
 ---
 
 Staking is the process of temporarily locking tez on the Tezos platform in exchange for rewards.
@@ -14,7 +14,7 @@ Two main groups stake on Tezos:
 
 - Bakers, the creators of new blocks in Tezos, must stake 6,000 tez to receive the right to "bake" blocks and to receive rewards for baking those blocks.
 Their staked tez ensures that they bake correctly, because part of their stake is taken ("slashed") if they misbehave.
-For more information about staking for baking purposes, see [Baking](/architecture/bakers).
+For more information about staking for baking purposes, see [Bakers](/architecture/bakers).
 
 - Any Tezos user can stake tez with a baker and earn rewards.
 In exchange for staking tez with a baker, users automatically receive a portion of the baker's rewards in proportion to how much they stake.
@@ -50,6 +50,25 @@ The process of unstaking has these main steps:
 1. When the user wants to stop staking, they decrease the amount that they have staked or unstake all of their staked tez.
 
 1. After a delay of about 10 days, the tez are unfrozen in their account and the user can use that tez as usual.
+
+Here are a few other things to know about staking as a Tezos user:
+
+- A Tezos account can have only one delegate at a time.
+For this reason, an account can stake with only one baker at a time.
+If you want to change bakers, you can unstake from the current baker, wait for the unstaking delay, and stake with a new baker.
+
+- The baker that you stake with has no control over your tez, but your staked and delegated tez counts toward the baker's voting rights.
+When it's time to vote on upgrades to Tezos, as described in [Governance and self-amendment](/architecture/governance), your baker's voting power includes the tez you have staked with them.
+
+- Before user staking was introduced to Tezos, users delegated their tez to bakers and bakers could choose to reward users for doing so.
+You can still delegate without staking, but the primary way users earn rewards now is to both delegate and stake.
+
+:::warning Risks of staking
+
+Your staked tez is subject to the same penalties as the baker's staked tez.
+In the rare event that your baker is punished ("slashed") for misbehaving, your tez is also slashed.
+
+:::
 
 ## How to stake
 

--- a/docs/using/staking.md
+++ b/docs/using/staking.md
@@ -2,7 +2,7 @@
 title: Staking
 authors: "Tim McMackin"
 last_update:
-  date: 13 January 2025
+  date: 15 January 2025
 ---
 
 Staking is the process of temporarily locking tez on the Tezos platform in exchange for rewards.
@@ -54,6 +54,9 @@ The process of unstaking has these main steps:
 ## How to stake
 
 The easiest way to stake is to use the staking web application at https://stake.tezos.com, which walks you through the process.
+If you don't want to use this application, some wallets have built-in staking functionality that you can use instead.
+Similarly, some cryptocurrency exchanges allow you to stake directly from their interfaces.
+However, you should evaluate these staking functions carefully because they may have different conditions and rewards than staking directly through the Tezos system and https://stake.tezos.com.
 
 :::warning
 

--- a/docs/using/staking.md
+++ b/docs/using/staking.md
@@ -51,7 +51,7 @@ The process of unstaking has these main steps:
 
 1. After a delay of about 10 days, the tez are unfrozen in their account and the user can use that tez as usual.
 
-Here are a few other things to know about staking as a Tezos user:
+Here are a few other things to know about delegating and staking as a Tezos user:
 
 - A Tezos account can have only one delegate at a time.
 For this reason, an account can stake with only one baker at a time.

--- a/docs/using/staking.md
+++ b/docs/using/staking.md
@@ -78,10 +78,16 @@ The staking app shows your account balance and how much you have staked.
 1. Click **Select Baker** and select a baker to delegate and stake to.
 
    To choose a baker, you can look up bakers in a block explorer by their addresses.
-   For example, the block explorer tzkt.io has information on bakers at https://tzkt.io/bakers.
-   This page shows information about staking and delegating with each baker, including the fees they charge and their capacity.
+   For example, the block explorer tzkt.io has information on bakers at https://tzkt.io/bakers and tzstats.com has information at https://tzstats.com/bakers.
+   Evaluate bakers by comparing information about them, including:
 
-   Before choosing a baker, look at the fees they charge and ensure that they have enough free space for the amount of tez you intend to stake.
+   - The fees they charge (commission) on staked funds
+   - Their capacity for additional staked funds (free space)
+   - How reliable they are as a baker (how often they bake blocks when they have the opportunity)
+   - Whether they have been penalized (slashed)
+   - Whether they are public (accepting stake from any user) or private (not accepting stake from other users)
+   - Whether they are supported by a corporation or not
+
    For example, the bakers in this picture all have free space for staking:
 
    <img alt="The TzKT block explorer, showing bakers with different capacities for staking" src="/img/using/staking-capacity.png" style={{width: 500}} />

--- a/docs/using/staking.md
+++ b/docs/using/staking.md
@@ -60,7 +60,7 @@ If you want to change bakers, you can unstake from the current baker, wait for t
 - The baker that you stake with has no control over your tez, but your staked and delegated tez counts toward the baker's voting rights, when it's time to vote on upgrades to Tezos, as described in [Governance and self-amendment](/architecture/governance).
 
 - Before user staking was introduced to Tezos, users delegated their tez to bakers and bakers could choose to reward users for doing so.
-You can still delegate without staking, but the primary way users earn rewards now is to both delegate and stake.
+You can still delegate without staking, but the primary way users earn rewards now is to both delegate and stake. Just delegating tez incurs less risks but brings only a fraction of the rewards.
 
 :::warning Risks of staking
 

--- a/docs/using/staking.md
+++ b/docs/using/staking.md
@@ -57,8 +57,7 @@ Here are a few other things to know about delegating and staking as a Tezos user
 For this reason, an account can stake with only one baker at a time.
 If you want to change bakers, you can unstake from the current baker, wait for the unstaking delay, and stake with a new baker.
 
-- The baker that you stake with has no control over your tez, but your staked and delegated tez counts toward the baker's voting rights.
-When it's time to vote on upgrades to Tezos, as described in [Governance and self-amendment](/architecture/governance), your baker's voting power includes the tez you have staked with them.
+- The baker that you stake with has no control over your tez, but your staked and delegated tez counts toward the baker's voting rights, when it's time to vote on upgrades to Tezos, as described in [Governance and self-amendment](/architecture/governance).
 
 - Before user staking was introduced to Tezos, users delegated their tez to bakers and bakers could choose to reward users for doing so.
 You can still delegate without staking, but the primary way users earn rewards now is to both delegate and stake.


### PR DESCRIPTION
Before we remove baking-related pages from opentezos and direct baking and staking info here, make sure that docs.tezos.com has all of the info from that page.

This PR has a few small updates from these pages, including a few things to check before selecting a baker and the info that some wallets and exchanges have built-in staking functions.

It takes info from these pages:
- https://opentezos.com/node-baking/baking/bakers_list/
- https://opentezos.com/node-baking/baking/delegating/
- https://opentezos.com/node-baking/baking/cli-baker/