### PR TITLE
How to revoke a consensus key and drain with it

### DIFF
--- a/docs/tutorials/join-dal-baker/verify-rights.md
+++ b/docs/tutorials/join-dal-baker/verify-rights.md
@@ -166,6 +166,12 @@ During this time you can leave the baking daemon running with the old consensus 
 
 1. When the new consensus key is active, stop the baking daemon and restart it with the new consensus key.
 
+To revoke the consensus key, set the consensus key to the baker key, as in this command:
+
+```bash
+octez-client set consensus key for my_baker to my_baker
+```
+
 ## Optional: Unstaking your tez and receiving your baking rewards
 
 If you leave the baker running, you can see rewards accrue by running the command `octez-client get staked balance for my_baker`.

--- a/docs/tutorials/join-dal-baker/verify-rights.md
+++ b/docs/tutorials/join-dal-baker/verify-rights.md
@@ -172,6 +172,12 @@ To revoke the consensus key, set the consensus key to the baker key, as in this 
 octez-client set consensus key for my_baker to my_baker
 ```
 
+Consensus keys can transfer the liquid (unstaked) tez from the baker key to any other account with the `drain delegate` command, as in this example:
+
+```bash
+octez-client drain delegate my_baker to consensus_key with consensus_key
+```
+
 ## Optional: Unstaking your tez and receiving your baking rewards
 
 If you leave the baker running, you can see rewards accrue by running the command `octez-client get staked balance for my_baker`.


### PR DESCRIPTION
How to revoke a consensus key and use it to drain, based on info in https://opentezos.com/node-baking/baking/consensus-key/#register-a-consensus-key.