### PR TITLE
Link to system requirements for Octez

### DIFF
--- a/docs/developing/octez-client.md
+++ b/docs/developing/octez-client.md
@@ -16,3 +16,4 @@ Other parts of Octez allow you to host, manage, and monitor nodes, bake blocks, 
 
 This documentation is an overview of the Octez client for Tezos smart contract and dApp developers.
 For more detailed information, see the [Octez documentation](https://tezos.gitlab.io/) and opentezos.com.
+For system requirements, see the documentation for the latest release of the Octez suite here: https://tezos.gitlab.io/releases/latest.html.

--- a/docs/tutorials/join-dal-baker.md
+++ b/docs/tutorials/join-dal-baker.md
@@ -66,6 +66,7 @@ The following diagram shows these daemons with a blue background:
 ## Prerequisites
 
 To run the Octez daemons persistently, you need a cloud-based computer or a computer that stays running constantly.
+For other system requirements, see the documentation for the latest release of the Octez suite here: https://tezos.gitlab.io/releases/latest.html.
 
 ## References
 


### PR DESCRIPTION
The link https://tezos.gitlab.io/releases/latest.html should always link to information for the current release of Octez.