### PR TITLE
Add tiles for these two tutorials

### DIFF
--- a/docs/tutorials.mdx
+++ b/docs/tutorials.mdx
@@ -73,7 +73,7 @@ These tutorials contain multiple parts and are intended for developers with some
   title="Run a tezos node in 5 steps"
   emoji="🍞"
   href="/tutorials/join-dal-baker"
-  description="See a complete walkthrough of setting up a baking operation including a Tezos node, DAL node, and baker"
+  description="See a complete walkthrough of becoming a baker by setting up a Tezos node, DAL node, and baker"
   link="Start tutorial"
 />
 

--- a/docs/tutorials.mdx
+++ b/docs/tutorials.mdx
@@ -54,6 +54,14 @@ These tutorials contain multiple parts and are intended for developers with some
 />
 
 <TutorialCard
+  title="Create a fungible token with the SmartPy FA2 library"
+  emoji="🏭"
+  href="/tutorials/smartpy-fa2-fungible"
+  description="Create standards-compliant tokens with the SmartPy language and its FA2 library and work with them in your wallet"
+  link="Start tutorial"
+/>
+
+<TutorialCard
   title="Create NFTs from a web application"
   emoji="🚀"
   href="/tutorials/create-nfts"
@@ -62,10 +70,10 @@ These tutorials contain multiple parts and are intended for developers with some
 />
 
 <TutorialCard
-  title="Join the DAL as a baker in 5 steps"
+  title="Run a tezos node in 5 steps"
   emoji="🍞"
   href="/tutorials/join-dal-baker"
-  description="Learn how to participate in the Data Availability Layer, which is a peer-to-peer network for sharing data across Tezos"
+  description="See a complete walkthrough of setting up a baking operation including a Tezos node, DAL node, and baker"
   link="Start tutorial"
 />
 


### PR DESCRIPTION
Two intermediate tutorials have no tiles on https://docs.tezos.com/tutorials. This PR adds them.

Preview: https://docs-staging-git-tutorial-tiles-trili-tech.vercel.app/tutorials#intermediate

<img width="909" alt="Screenshot 2025-01-17 at 11 47 46 AM" src="https://github.com/user-attachments/assets/75f3fe4d-34e0-4690-a262-323ab6153b70" />
