### PR TITLE
Must use absolute links to files not processed by Docusaurus

### DIFF
--- a/docs/reference/textfiles.md
+++ b/docs/reference/textfiles.md
@@ -7,5 +7,5 @@ last_update:
 
 To access the documentation on this site for use with an LLM, download these text files:
 
-- All documentation text: [allPageSourceFiles.txt](/allPageSourceFiles.txt)
-- All tutorial text: [allTutorials.txt](/allTutorials.txt)
+- All documentation text: [allPageSourceFiles.txt](https://docs.tezos.com/allPageSourceFiles.txt)
+- All tutorial text: [allTutorials.txt](https://docs.tezos.com/allTutorials.txt)


### PR DESCRIPTION
Per the warning at the bottom of [this page](https://docusaurus.io/docs/markdown-features/links), you can't link from a file that Docusaurus processes to a file that it does not process with a relative or root-relative link. For this reason, when you go to https://docs.tezos.com/textfiles and click on a file name, the site will show a 404 even though the path is correct. Setting the links to absolute https links fixes this.