### PR TITLE
[baking-with-ledger] handles feedback

### DIFF
--- a/docs/tutorials/bake-with-ledger/run-baker.md
+++ b/docs/tutorials/bake-with-ledger/run-baker.md
@@ -21,6 +21,12 @@ Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of 
 
     You can then continue to set up your baker account.
 
+    ```bash
+    octez-client gen keys my_baker
+    octez-client register key my_baker as delegate with consensus key consensus_key
+    octez-client stake 6000 for my_baker
+    ```
+
     By registering your baker as a delegate with the ledger key as the consensus key, the baker daemon will sign using the Ledger.
 
  - If you **don't want to use a consensus key**, use your Ledger key directly as a baker. Import it from the `octez-signer` remote with the following command:
@@ -32,7 +38,15 @@ Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of 
     > Replace the `tz...` with the public key hash of your Ledger baking key.
 
     In that case, to be able to sign the operations required to set up your baker, you need to use the `Tezos Wallet (XTZ)` application.
-    Quit the `Tezos Baking` application and open the `Tezos Wallet (XTZ)` application.
+    Quit the `Tezos Baking` application and open the `Tezos Wallet (XTZ)` application. Then setup your baker.
+
+    ```bash
+    octez-client import secret key my_baker remote:tz...
+    octez-client register key my_baker as delegate
+    octez-client stake 6000 for my_baker
+    ```
+
+    Your baker account is now set up and ready to bake using the Ledger.
 
 ## Before running the Octez baking daemon
 

--- a/docs/tutorials/bake-with-ledger/run-baker.md
+++ b/docs/tutorials/bake-with-ledger/run-baker.md
@@ -11,24 +11,6 @@ Now that the Ledger baking key is set up, you can follow the steps of [Run a Tez
 
 Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of the tutorial, and make following changes in [Step 2: Set up a baker account](/tutorials/join-dal-baker/prepare-account).
 
- - If you **want to use a consensus key**, instead of generating it, use the Ledger key. To do so, import it from the `octez-signer` remote with the following command:
-
-    ```bash
-    octez-client import secret key consensus_key remote:tz...
-    ```
-
-    > Replace the `tz...` with the public key hash of your Ledger baking key.
-
-    You can then continue to set up your baker account.
-
-    ```bash
-    octez-client gen keys my_baker
-    octez-client register key my_baker as delegate with consensus key consensus_key
-    octez-client stake 6000 for my_baker
-    ```
-
-    By registering your baker as a delegate with the ledger key as the consensus key, the baker daemon will sign using the Ledger.
-
  - If you **don't want to use a consensus key**, use your Ledger key directly as a baker. Import it from the `octez-signer` remote with the following command:
 
     ```bash
@@ -47,6 +29,24 @@ Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of 
     ```
 
     Your baker account is now set up and ready to bake using the Ledger.
+
+ - If you **want to use a consensus key**, instead of generating it, use the Ledger key. To do so, import it from the `octez-signer` remote with the following command:
+
+    ```bash
+    octez-client import secret key consensus_key remote:tz...
+    ```
+
+    > Replace the `tz...` with the public key hash of your Ledger baking key.
+
+    You can then continue to set up your baker account.
+
+    ```bash
+    octez-client gen keys my_baker
+    octez-client register key my_baker as delegate with consensus key consensus_key
+    octez-client stake 6000 for my_baker
+    ```
+
+    By registering your baker as a delegate with the ledger key as the consensus key, the baker daemon will sign using the Ledger.
 
 ## Before running the Octez baking daemon
 

--- a/docs/tutorials/bake-with-ledger/run-baker.md
+++ b/docs/tutorials/bake-with-ledger/run-baker.md
@@ -11,7 +11,9 @@ Now that the Ledger baking key is set up, you can follow the steps of [Run a Tez
 
 Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of the tutorial, and make following changes in [Step 2: Set up a baker account](/tutorials/join-dal-baker/prepare-account).
 
- - If you **don't want to use a consensus key**, use your Ledger key directly as a baker. Import it from the `octez-signer` remote with the following command:
+You can use your Ledger key as your main baker key or you could use Ledger key as consensus key.
+
+ - To **use the Ledger key as your main baker key**, import it from the `octez-signer` remote with the following command:
 
     ```bash
     octez-client import secret key my_baker remote:tz...
@@ -19,8 +21,8 @@ Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of 
 
     > Replace the `tz...` with the public key hash of your Ledger baking key.
 
-    In that case, to be able to sign the operations required to set up your baker, you need to use the `Tezos Wallet (XTZ)` application.
-    Quit the `Tezos Baking` application and open the `Tezos Wallet (XTZ)` application. Then setup your baker.
+    Run and sign the following operations to set up your baker. You will need to use the `Tezos Wallet (XTZ)` application.
+    Quit the `Tezos Baking` application and open the `Tezos Wallet (XTZ)` application. Then set up your baker.
 
     ```bash
     octez-client import secret key my_baker remote:tz...
@@ -30,7 +32,7 @@ Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of 
 
     Your baker account is now set up and ready to bake using the Ledger.
 
- - If you **want to use a consensus key**, instead of generating it, use the Ledger key. To do so, import it from the `octez-signer` remote with the following command:
+ - If you **want to use your Ledger key as a consensus key**, import it from the `octez-signer` remote with the following command:
 
     ```bash
     octez-client import secret key consensus_key remote:tz...
@@ -38,7 +40,7 @@ Complete the [Step 1: Run an Octez node](/tutorials/join-dal-baker/run-node) of 
 
     > Replace the `tz...` with the public key hash of your Ledger baking key.
 
-    You can then continue to set up your baker account.
+    With Ledger key imported as consensus key, you will need to generate/set up your baker key separately. You can then continue to set up your baker account. See the following commands:
 
     ```bash
     octez-client gen keys my_baker


### PR DESCRIPTION
Some feedback on our `Baking with Ledger` tutorial has been received.
This PR deals with these comments.

 - [x] The baker account set up was not clear ; the readers were lost and do not clearly see what they should do.
         The [command to runs](https://docs.tezos.com/tutorials/join-dal-baker/prepare-account) for it as been included.