### PR TITLE
Restore upgrading Unity page

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -218,6 +218,7 @@ const sidebars = {
         'unity/connecting-accounts',
         'unity/calling-contracts',
         'unity/managing-tokens',
+        'unity/upgrading',
         {
           type: 'category',
           label: 'Reference',


### PR DESCRIPTION
Left this page out of the TOC by mistake.

Here's the page, it just needs to be added to the sidebar: https://docs.tezos.com/unity/upgrading