### PR TITLE
Filter dependencies by file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ dependencies:
 
 The current versions of these tools are set in the file `src/scripts/dependencies.json`.
 When you run `npm run check-dependencies`, a script checks for files that need to be updated.
-You can check specific tools by passing them to the script, as in `npm run check-dependencies smartpy taquito`.
+
+- You can check specific tools by passing them to the script, as in `npm run check-dependencies -- --dependencies=smartpy,taquito`.
+- By default, the script checks for differences down to the fixpack level, but you can pass `--major` or `--minor` to check for differences at those levels.
+- By default, it checks all files, but you can pass individual files to check in a comma-separated list, as in `npm run check-dependencies -- --filesToCheck=docs/developing/octez-client/accounts.md,docs/tutorials/build-your-first-app.md`.
 
 ## Search
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When you run `npm run check-dependencies`, a script checks for files that need t
 
 - You can check specific tools by passing them to the script, as in `npm run check-dependencies -- --dependencies=smartpy,taquito`.
 - By default, the script checks for differences down to the fixpack level, but you can pass `--major` or `--minor` to check for differences at those levels.
-- By default, it checks all files, but you can pass individual files to check in a comma-separated list, as in `npm run check-dependencies -- --filesToCheck=docs/developing/octez-client/accounts.md,docs/tutorials/build-your-first-app.md`.
+- By default, it checks all files, but you can pass individual files to check after the other arguments, as in `npm run check-dependencies -- --major -d=smartpy,taquito docs/developing/octez-client/accounts.md docs/tutorials/build-your-first-app.md`.
 
 ## Search
 

--- a/src/scripts/check_dependencies.mjs
+++ b/src/scripts/check_dependencies.mjs
@@ -18,8 +18,8 @@ By default, this script checks for differences down to the fixpack level.
 You can pass --major or --minor to ignore differences up to the specified level.
 
 By default, this script checks all files.
-You can pass individual files to check in a comma-separated list with the --filesToCheck parameter, as in
-npm run check-dependencies -- --filesToCheck=docs/developing/octez-client/accounts.md,docs/tutorials/build-your-first-app.md
+You can pass individual files to check as anonymous arguments after the other parameters, as in
+npm run check-dependencies -- --major -d=smartpy,taquito docs/developing/octez-client/accounts.md docs/tutorials/build-your-first-app.md
 
 */
 
@@ -43,24 +43,16 @@ const { currentVersions } = JSON.parse(dependencyConfig);
 // Set up parameters
 const argv = minimist(process.argv.slice(2), {
   boolean: ['major', 'minor'],
-  string: ['filesToCheck', 'dependencies'],
+  string: ['dependencies'],
   alias: {
-    f: 'filesToCheck',
     d: 'dependencies',
   },
-  unknown: (unknownArg) => {
-    console.error('Error: unknown argument', unknownArg);
-    console.error('Pass dependencies to check in a comma-separated list, as in --dependencies=octez,smartpy,ligo.');
-    console.error('Pass the version level to check with --major or --minor, or omit the version level to check down to the fixpack level.');
-    console.error('Pass files to check in a comma-separated list, as in --filesToCheck=docs/dApps/wallets.md,docs/developing/octez-client/accounts.md.')
-    process.exit(1);
-  }
 });
 
 // By default, check all files
-const filesToCheckPromise = argv['filesToCheck'] ?
-  argv['filesToCheck']
-  .split(',')
+// But if file names are passed as anonymous params, check only those files
+const filesToCheckPromise = argv['_'].length > 0 ?
+  argv['_']
   .map((shortPath) => path.resolve(baseFolder, shortPath))
   : glob(docsFolder + '/**/*.{md,mdx}');
 

--- a/src/scripts/check_dependencies.mjs
+++ b/src/scripts/check_dependencies.mjs
@@ -49,9 +49,6 @@ const argv = minimist(process.argv.slice(2), {
     d: 'dependencies',
   },
   unknown: (unknownArg) => {
-    if (currentVersions[unknownArg]) {
-      return true;
-    }
     console.error('Error: unknown argument', unknownArg);
     console.error('Pass dependencies to check in a comma-separated list, as in --dependencies=octez,smartpy,ligo.');
     console.error('Pass the version level to check with --major or --minor, or omit the version level to check down to the fixpack level.');
@@ -59,14 +56,24 @@ const argv = minimist(process.argv.slice(2), {
     process.exit(1);
   }
 });
+
 // By default, check all files
 const filesToCheckPromise = argv['filesToCheck'] ?
   argv['filesToCheck']
   .split(',')
   .map((shortPath) => path.resolve(baseFolder, shortPath))
   : glob(docsFolder + '/**/*.{md,mdx}');
+
 // By default, check all dependencies
 const dependenciesToCheck = argv['dependencies'] ? argv['dependencies'].split(',') : Object.keys(currentVersions);
+dependenciesToCheck.forEach((oneDependency) => {
+  if (!Object.keys(currentVersions).includes(oneDependency)) {
+    console.error('Unknown dependency:', oneDependency);
+    process.exit(1);
+  }
+});
+
+// By default, check to the fixpack version
 const checkMajor = argv.major;
 const checkMinor = argv.minor;
 if (checkMajor && checkMinor) {

--- a/src/scripts/check_dependencies.mjs
+++ b/src/scripts/check_dependencies.mjs
@@ -53,7 +53,7 @@ const argv = minimist(process.argv.slice(2), {
 // But if file names are passed as anonymous params, check only those files
 const filesToCheckPromise = argv['_'].length > 0 ?
   argv['_']
-  .map((shortPath) => path.resolve(baseFolder, shortPath))
+    .map((shortPath) => path.resolve(baseFolder, shortPath))
   : glob(docsFolder + '/**/*.{md,mdx}');
 
 // By default, check all dependencies
@@ -105,12 +105,13 @@ const printDependencies = async () => {
     files
       .sort()
       .map(async (filePath) => {
-      const fileContents = await fs.promises.readFile(filePath, 'utf8');
-      const frontMatter = matter(fileContents).data;
-      return {
-        filePath: path.relative(baseFolder, filePath),
-        frontMatter };
-    })
+        const fileContents = await fs.promises.readFile(filePath, 'utf8');
+        const frontMatter = matter(fileContents).data;
+        return {
+          filePath: path.relative(baseFolder, filePath),
+          frontMatter
+        };
+      })
   );
 
   // Filter to dependencies that we care about


### PR DESCRIPTION
Eventually we'll want to filter the dependency check by file, so this PR reworks the script into accepting three params:

- You can check specific tools by passing them to the script, as in `npm run check-dependencies -- --dependencies=smartpy,taquito`.
- By default, the script checks for differences down to the fixpack level, but you can pass `--major` or `--minor` to check for differences at those levels.
- By default, it checks all files, but you can pass individual files to check in a comma-separated list, as in `npm run check-dependencies -- --filesToCheck=docs/developing/octez-client/accounts.md,docs/tutorials/build-your-first-app.md`.

The script has error-checking to catch unknown parameters and dependencies. If you pass an incorrect file path, you'll get the usual Node ENOENT error for the missing file.