### PR TITLE
Allow paths or specific files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When you run `npm run check-dependencies`, a script checks for files that need t
 
 - You can check specific tools by passing them to the script, as in `npm run check-dependencies -- --dependencies=smartpy,taquito`.
 - By default, the script checks for differences down to the fixpack level, but you can pass `--major` or `--minor` to check for differences at those levels.
-- By default, it checks all files, but you can pass individual files to check after the other arguments, as in `npm run check-dependencies -- --major -d=smartpy,taquito docs/developing/octez-client/accounts.md docs/tutorials/build-your-first-app.md`.
+- By default, it checks all files, but you can pass individual files or folders to check after the other arguments, as in `npm run check-dependencies -- --major -d=smartpy,taquito docs/developing/octez-client/accounts.md docs/tutorials/build-your-first-app.md` or `npm run check-dependencies -- --major -d=smartpy,taquito docs/tutorials`.
 
 ## Search
 

--- a/src/scripts/check_dependencies.mjs
+++ b/src/scripts/check_dependencies.mjs
@@ -21,6 +21,8 @@ By default, this script checks all files.
 You can pass individual files to check as anonymous arguments after the other parameters, as in
 npm run check-dependencies -- --major -d=smartpy,taquito docs/developing/octez-client/accounts.md docs/tutorials/build-your-first-app.md
 
+You can also pass folders to check, as in
+npm run check-dependencies -- --major -d=smartpy,taquito docs/tutorials
 */
 
 import path, { dirname } from 'path';
@@ -41,6 +43,7 @@ const dependencyConfig = fs.readFileSync(path.resolve(__dirname, 'dependencies.j
 const { currentVersions } = JSON.parse(dependencyConfig);
 
 // Set up parameters
+// Anonymous params are in argv['_']
 const argv = minimist(process.argv.slice(2), {
   boolean: ['major', 'minor'],
   string: ['dependencies'],
@@ -48,13 +51,6 @@ const argv = minimist(process.argv.slice(2), {
     d: 'dependencies',
   },
 });
-
-// By default, check all files
-// But if file names are passed as anonymous params, check only those files
-const filesToCheckPromise = argv['_'].length > 0 ?
-  argv['_']
-    .map((shortPath) => path.resolve(baseFolder, shortPath))
-  : glob(docsFolder + '/**/*.{md,mdx}');
 
 // By default, check all dependencies
 const dependenciesToCheck = argv['dependencies'] ? argv['dependencies'].split(',') : Object.keys(currentVersions);
@@ -71,6 +67,34 @@ const checkMinor = argv.minor;
 if (checkMajor && checkMinor) {
   console.error('Include either --major or --minor, not both');
   process.exit(1);
+}
+
+const getFilesToCheck = async () => {
+  // By default, check all files
+  if (argv['_'].length === 0) {
+    return glob(docsFolder + '/**/*.{md,mdx}');
+  }
+  // But if file names or paths are passed as anonymous params, check only those files
+  return argv['_'].reduce(async (allFilesPromise, oneShortPath) => {
+    const fullPath = path.resolve(baseFolder, oneShortPath);
+    const allFiles = await allFilesPromise;
+    // Is this a path or a file name?
+    return fs.promises.lstat(fullPath)
+      .then(async (lstatResult) => {
+        if (lstatResult.isFile()) {
+          return allFiles.concat([fullPath]);
+        } else if (lstatResult.isDirectory()) {
+          return allFiles.concat(await glob(path.resolve(fullPath, '**/*.{md,mdx}')));
+        } else {
+          throw 'Path does not appear to be either a file or a directory.';
+        }
+      })
+      .catch((err) => {
+        console.error('Error: Could not resolve this file or path:', oneShortPath);
+        console.error(err);
+        process.exit(1);
+      });
+  }, Promise.resolve([]));
 }
 
 // Function to compare versions based on whether we care about major, minor, or patch versions
@@ -98,7 +122,7 @@ const isOldVersion = (v1String, v2String) => {
 
 const printDependencies = async () => {
   // Get files to check
-  const files = await filesToCheckPromise;
+  const files = await getFilesToCheck();
 
   // Get front matter for each file
   const filesAndFrontMatter = await Promise.all(


### PR DESCRIPTION
For dependency checks we should be able to pass individual paths or files. This PR allows you to pass any combination, as in these examples:

```
npm run check-dependencies -- --major -d=smartpy,taquito docs/developing/octez-client/accounts.md docs/tutorials

npm run check-dependencies -- --major -d=smartpy,taquito docs/*
```

The shell expands the `*` in the anonymous arguments before it gets to the script but I think I've got it working despite that.
