### PR TITLE
DAL updates

### DIFF
--- a/docs/tutorials/build-files-archive-with-dal/get-slot-info.md
+++ b/docs/tutorials/build-files-archive-with-dal/get-slot-info.md
@@ -2,7 +2,7 @@
 title: "Part 3: Getting slot information"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 11 September 2024
+  date: 4 February 2025
 ---
 
 When clients send data to the DAL, they must choose which slot to put it in.
@@ -40,8 +40,10 @@ To run a DAL node, you must configure a set of cryptographic parameters for it a
 1. Run this command to install the trusted setup:
 
    ```bash
-   ./install_dal_trusted_setup.sh --legacy
+   ./install_dal_trusted_setup.sh
    ```
+
+   If you are using a version of Octez prior to 21.1, add the `--legacy` argument to this command.
 
 1. Run this command to start a DAL node and monitor slot 0:
 

--- a/docs/tutorials/build-files-archive-with-dal/publishing-on-the-dal.md
+++ b/docs/tutorials/build-files-archive-with-dal/publishing-on-the-dal.md
@@ -2,7 +2,7 @@
 title: "Part 4: Publishing on the DAL"
 authors: Tezos core developers, Tim McMackin
 last_update:
-  date: 27 January 2025
+  date: 4 February 2025
 ---
 
 Now that you can get information about the DAL, the next step is to publish data to it and verify that the kernel can access it.
@@ -100,6 +100,20 @@ The slot that you published the message to turns blue, as in this picture:
    ```
 
    You can verify your message by converting the bytes in the message back to the first 10 characters of the string "Hello, World!"
+
+   You can also access the data from the DAL node by running this command, where `<PUBLISHED_LEVEL>` is the level that you published the data in and `<SLOT_INDEX>` is the slot that you used:
+
+   ```bash
+   curl localhost:10732/levels/<PUBLISHED_LEVEL>/slots/<SLOT_INDEX>/content | more
+   ```
+
+   This RPC endpoint returns the full contents of the slot, padded with zeros to the standard size of DAL slots on that network.
+   You can copy the contents, omitting the zeros, and use a hexadecimal to string conversion tool to convert it back to a string.
+   Online tools can convert hex to string, or you can use the `xxd` program, as in this example, which returns `Hello, world!`:
+
+   ```bash
+   echo -n '48656c6c6f2c20776f726c6421'  | xxd -r -p
+   ```
 
 ## Troubleshooting
 

--- a/docs/tutorials/build-files-archive-with-dal/publishing-on-the-dal.md
+++ b/docs/tutorials/build-files-archive-with-dal/publishing-on-the-dal.md
@@ -136,10 +136,18 @@ If you don't see the message that the slot is attested and contains your data, t
         from my_wallet for slot 10 with proof "${proof}"
       ```
 
-- If the slot turned red, it's possible that the attesters for the network are offline.
-In this case, your Smart Rollup cannot use the data on the DAL, but the blue slot in Explorus verifies that you published it successfully.
-Without active attesters, you cannot continue with this tutorial.
-You can try running your own attester by getting tez from the faucet and running a baker as described in [Join the DAL as a baker, in 5 steps](/tutorials/join-dal-baker).
+- If the slot turned red on Explorus, these things may have happened:
+
+   - The attesters could not download the data to attest it.
+   This can happen if your DAL node is misconfigured and did not share the data with other DAL nodes.
+   Verify that your DAL node is accessible from outside your local network and that it is running with the correct arguments.
+   For example, DAL nodes can fail to share the data if they are configured with an attester configuration but are not connected to a baker with attestation rights.
+   You can try deleting the DAL node configuration and restarting the node with the correct `--observer-profiles` argument.
+
+   - The attesters for the network are offline.
+   In this case, your Smart Rollup cannot use the data on the DAL, but the blue slot in Explorus verifies that you published it successfully.
+   Without active attesters, you cannot continue with this tutorial.
+   You can try running your own attester by getting tez from the faucet and running a baker as described in [Join the DAL as a baker, in 5 steps](/tutorials/join-dal-baker).
 
 ## Publishing files
 


### PR DESCRIPTION
- `--legacy` is no longer required for the DAL trusted setup but I left it in there for older versions of Octez
- Add troubleshooting step to verify that the DAL node is configured
- Add how to get DAL data via RPC