### PR TITLE
Backup and restore instructions for nonce files

### DIFF
--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -129,7 +129,7 @@ You can upgrade accusers with a similar process.
 The Octez baking daemon stores persistent operational data in the Octez client's data directory, notably consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
 If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
 These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network.
-All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy bakers have the `net<NETWORK_ID>_nonces` file.
+All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy baking deployments have the `net<NETWORK_ID>_nonces` file.
 
 ## Calculating the delay for attestation rights
 

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -129,9 +129,9 @@ You can upgrade accusers with a similar process.
 The Octez baking daemon stores persistent operational data in the Octez client's data directory, notably consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
 If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
 These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network, such as `netXdQprcVkpaWU_stateful_nonces` for Mainnet or `netXnHfVqm9ie_stateful_nonces` for Ghostnet.
-All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy baking deployments running versions of Octez prior to 20.0rc1 have the `net<NETWORK_ID>_nonces` file.
+All deployments have the `net<NETWORK_ID>_stateful_nonces` file but only legacy baking deployments running versions of Octez prior to 20.0rc1 have the `net<NETWORK_ID>_nonces` file.
 
-After you have moved the nonce files and verified that the baker runs normally for one cycle, you can remove the legacy `net<NETWORK_ID>_nonces` file.
+After you have moved the nonce files to the new machine and verified that the baker runs normally for one cycle, you can remove the legacy `net<NETWORK_ID>_nonces` file.
 
 ## Calculating the delay for attestation rights
 

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -128,7 +128,7 @@ You can upgrade accusers with a similar process.
 
 The Octez baking daemon stores persistent operational data in the Octez client's data directory, notably consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
 If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
-These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network.
+These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network, such as `netXdQprcVkpaWU_stateful_nonces` for Mainnet or `netXnHfVqm9ie_stateful_nonces` for Ghostnet.
 All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy baking deployments have the `net<NETWORK_ID>_nonces` file.
 
 ## Calculating the delay for attestation rights

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -126,7 +126,7 @@ You can upgrade accusers with a similar process.
 
 ## Backing up and restoring the baker
 
-The Octez baking daemon stores relies in the Octez client's data directory to store persistent operational data, notably  consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
+The Octez baking daemon stores persistent operational data in the Octez client's data directory, notably consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
 If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
 These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network.
 All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy bakers have the `net<NETWORK_ID>_nonces` file.

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -126,7 +126,7 @@ You can upgrade accusers with a similar process.
 
 ## Backing up and restoring the baker
 
-The Octez baking daemon stores no persistent data of its own, but it depends on files in the Octez client's data directory.
+The Octez baking daemon stores relies in the Octez client's data directory to store persistent operational data, notably  consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
 If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
 These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network.
 All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy bakers have the `net<NETWORK_ID>_nonces` file.

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -124,6 +124,13 @@ However, make sure not to run the baker twice **for the same protocol version an
 
 You can upgrade accusers with a similar process.
 
+## Backing up and restoring the baker
+
+The Octez baking daemon stores no persistent data of its own, but it depends on files in the Octez client's data directory.
+If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
+These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network.
+All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy bakers have the `net<NETWORK_ID>_nonces` file.
+
 ## Calculating the delay for attestation rights
 
 If you are setting up a new baker, you must wait until it receives attestation rights before it can bake blocks or attest to DAL data.

--- a/docs/tutorials/join-dal-baker/run-baker.md
+++ b/docs/tutorials/join-dal-baker/run-baker.md
@@ -129,7 +129,9 @@ You can upgrade accusers with a similar process.
 The Octez baking daemon stores persistent operational data in the Octez client's data directory, notably consensus high-water marks and [random seed nonces](https://tezos.gitlab.io/active/randomness_generation.html).
 If you want to back up the baker or move it to another machine and restore it, you must copy the nonce file or files from the Octez client's data directory to the equivalent directory on the new machine.
 These nonce files are named `net<NETWORK_ID>_stateful_nonces` and `net<NETWORK_ID>_nonces`, where `<NETWORK_ID>` is the ID of the network, such as `netXdQprcVkpaWU_stateful_nonces` for Mainnet or `netXnHfVqm9ie_stateful_nonces` for Ghostnet.
-All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy baking deployments have the `net<NETWORK_ID>_nonces` file.
+All systems have the `net<NETWORK_ID>_stateful_nonces` file but only legacy baking deployments running versions of Octez prior to 20.0rc1 have the `net<NETWORK_ID>_nonces` file.
+
+After you have moved the nonce files and verified that the baker runs normally for one cycle, you can remove the legacy `net<NETWORK_ID>_nonces` file.
 
 ## Calculating the delay for attestation rights
 


### PR DESCRIPTION
Need to backup nonce files if you move the baker to another machine.